### PR TITLE
Implement Task model with validation tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,35 @@
-from .llm import LLMClient
-from .router import Router
+"""Root package entrypoints for Jarvis pipeline."""
+
+from jarvis_core.task import Task, TaskCategory, TaskPriority, TaskStatus
+
+__all__ = [
+    "run_jarvis",
+    "Task",
+    "TaskCategory",
+    "TaskPriority",
+    "TaskStatus",
+    "LLMClient",
+    "Router",
+]
 
 
 def run_jarvis(task: str) -> str:
+    from jarvis_core.llm import LLMClient
+    from jarvis_core.router import Router
+
     llm = LLMClient(model="gemini-2.0-flash")
     router = Router(llm)
     result = router.run(task)
     return result.answer
+
+
+def __getattr__(name: str):
+    if name == "LLMClient":
+        from jarvis_core.llm import LLMClient
+
+        return LLMClient
+    if name == "Router":
+        from jarvis_core.router import Router
+
+        return Router
+    raise AttributeError(name)

--- a/docs/codex_progress.md
+++ b/docs/codex_progress.md
@@ -1,0 +1,47 @@
+# Codex Progress - Jarvis Core
+
+## Vision Summary
+- Jarvis Core turns open-ended research and career questions into structured tasks and orchestrates the right agents to execute them.
+- It converts natural language goals into actionable subtasks with clear inputs, constraints, and priorities.
+- It routes work to domain agents (literature, thesis writing, job hunting, news) via a registry and lightweight execution engine.
+- It validates outputs, triggers retries when results are incomplete or malformed, and keeps decisions auditable.
+- It centralizes logging and progress so humans can trace when, what, and which agent acted.
+- It favors small, iterative improvements while preserving public interfaces and avoiding hardcoded secrets.
+
+## Milestones (M1–M4) and Status
+- **M1: Minimal Jarvis Core (CLI base)** — Status: 進行中
+- **M2: External Tool Integration Skeleton** — Status: 未着手
+- **M3: Self-Evaluation & Retry** — Status: 未着手
+- **M4: UI Layer Connectivity (antigravity/MyGPT)** — Status: 未着手
+
+## Subtasks
+### M1: Minimal Jarvis Core
+- [x] Task model defined with id/category/goal/inputs/constraints/priority/status/history
+- [ ] Minimal planner that expands user goals into ordered subtasks (hardcoded per category acceptable)
+- [ ] Execution engine that sequences subtasks and invokes dummy agents
+- [ ] Simple CLI entry (e.g., `python -m jarvis_core.cli`) demonstrating end-to-end flow
+
+### M2: Agent Registry / Router & Tool Interfaces
+- [ ] Config-driven agent registry (YAML/TOML) mapping categories to agents/tools
+- [ ] Router that selects agents based on task metadata and registry configuration
+- [ ] Interface stubs for literature tools (paper-fetcher, mygpt-paper-analyzer) and job-hunting utilities
+- [ ] Basic configuration loader with environment override support
+
+### M3: Self-Evaluation & Retry Logic
+- [ ] Validation functions for common outputs (JSON schema, file existence checks, minimal sanity rules)
+- [ ] Retry policy with capped attempts and error-type differentiation
+- [ ] Mechanism to enqueue corrective subtasks when validation fails
+- [ ] Logging of evaluation outcomes and retry decisions
+
+### M4: UI / API Connectivity
+- [ ] HTTP or CLI wrapper callable from antigravity actions
+- [ ] Task ID–based progress query endpoint or CLI command
+- [ ] Auth/config plumbing separated from business logic (no hardcoded secrets)
+- [ ] Documentation for integrating with MyGPT or future dashboard
+
+## In-Progress Log
+- 2025-12-01T02:18Z — Repository review and initial codex_progress.md scaffold added (setup for M1 planning).
+- 2025-12-01T03:00Z — Implemented Task model at `jarvis_core/task.py` with enums for category/priority/status, added tests in `tests/test_task_model.py`, pytest passing locally.
+
+## Blockers
+- None identified yet.

--- a/jarvis_core/__init__.py
+++ b/jarvis_core/__init__.py
@@ -1,15 +1,42 @@
-# jarvis_core/__init__.py
-from .llm import LLMClient
-from .router import Router
+"""Jarvis Core package exports."""
+
+from .task import Task, TaskCategory, TaskPriority, TaskStatus
+
+__all__ = [
+    "run_jarvis",
+    "Task",
+    "TaskCategory",
+    "TaskPriority",
+    "TaskStatus",
+    "LLMClient",
+    "Router",
+]
+
 
 def run_jarvis(task: str) -> str:
     """
-    Jarvis のコア処理を 1 関数にまとめたラッパー。
-    どの環境（ローカル / 大学PC / antigravity）からも
-    これだけ呼べば同じ挙動になる。
+    High-level wrapper that orchestrates a task through the router.
+
+    Imports heavy dependencies lazily so that lightweight modules (e.g.,
+    task modeling) can be used without requiring LLM dependencies.
     """
-    # ここで使うモデルを一元管理
-    llm = LLMClient(model="gemini-2.0-flash")  # いま使っている設定
+
+    from .llm import LLMClient  # Local import to avoid optional dependency at package import time
+    from .router import Router
+
+    llm = LLMClient(model="gemini-2.0-flash")
     router = Router(llm)
     result = router.run(task)
     return result.answer
+
+
+def __getattr__(name: str):
+    if name == "LLMClient":
+        from .llm import LLMClient
+
+        return LLMClient
+    if name == "Router":
+        from .router import Router
+
+        return Router
+    raise AttributeError(name)

--- a/jarvis_core/task.py
+++ b/jarvis_core/task.py
@@ -1,0 +1,77 @@
+"""Task model definitions for Jarvis Core.
+
+The Task object captures the minimal contract shared across planners,
+routers, and execution components. It aligns with the abstract
+specification in ``docs/jarvis_vision.md`` and keeps validation light
+while enforcing allowed enum values.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class TaskCategory(str, Enum):
+    """Supported task categories for Jarvis Core."""
+
+    PAPER_SURVEY = "paper_survey"
+    THESIS = "thesis"
+    STUDY = "study"
+    JOB_HUNTING = "job_hunting"
+    GENERIC = "generic"
+
+
+class TaskPriority(str, Enum):
+    """Relative priority of a task."""
+
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+
+
+class TaskStatus(str, Enum):
+    """Lifecycle state of a task."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    BLOCKED = "blocked"
+    DONE = "done"
+    FAILED = "failed"
+
+
+@dataclass
+class Task:
+    """Canonical Task representation used by Jarvis Core components."""
+
+    id: str
+    category: TaskCategory
+    goal: str
+    inputs: Dict[str, Any]
+    constraints: Dict[str, Any] = field(default_factory=dict)
+    priority: TaskPriority = TaskPriority.NORMAL
+    status: TaskStatus = TaskStatus.PENDING
+    history: List[Any] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.category = self._validate_enum(self.category, TaskCategory, "category")
+        self.priority = self._validate_enum(self.priority, TaskPriority, "priority")
+        self.status = self._validate_enum(self.status, TaskStatus, "status")
+        self._validate_mapping("inputs", self.inputs)
+        self._validate_mapping("constraints", self.constraints)
+        if self.history is None:
+            self.history = []
+
+    @staticmethod
+    def _validate_enum(value: Any, enum_cls: type[Enum], field_name: str) -> Enum:
+        if isinstance(value, enum_cls):
+            return value
+        try:
+            return enum_cls(value)
+        except ValueError as exc:  # pragma: no cover - explicit mapping to ValueError
+            raise ValueError(f"Invalid {field_name}: {value}") from exc
+
+    @staticmethod
+    def _validate_mapping(field_name: str, value: Any) -> None:
+        if not isinstance(value, dict):
+            raise TypeError(f"{field_name} must be a dictionary; got {type(value).__name__}")

--- a/tests/test_task_model.py
+++ b/tests/test_task_model.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is on sys.path for direct module imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from jarvis_core.task import (  # noqa: E402
+    Task,
+    TaskCategory,
+    TaskPriority,
+    TaskStatus,
+)
+
+
+def test_task_creation_with_defaults():
+    task = Task(
+        id="task-1",
+        category=TaskCategory.PAPER_SURVEY,
+        goal="Survey CD73 literature",
+        inputs={"query": "CD73", "files": []},
+    )
+
+    assert task.priority == TaskPriority.NORMAL
+    assert task.status == TaskStatus.PENDING
+    assert task.history == []
+    assert task.category is TaskCategory.PAPER_SURVEY
+    assert task.inputs["query"] == "CD73"
+
+
+def test_task_rejects_invalid_category():
+    with pytest.raises(ValueError):
+        Task(
+            id="task-2",
+            category="invalid",  # type: ignore[arg-type]
+            goal="Do something",
+            inputs={},
+        )
+
+
+def test_task_rejects_invalid_priority_and_status():
+    with pytest.raises(ValueError):
+        Task(
+            id="task-3",
+            category=TaskCategory.GENERIC,
+            goal="Generic goal",
+            inputs={},
+            priority="urgent",  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError):
+        Task(
+            id="task-4",
+            category=TaskCategory.GENERIC,
+            goal="Generic goal",
+            inputs={},
+            status="unknown",  # type: ignore[arg-type]
+        )
+
+
+def test_history_default_is_isolated():
+    first = Task(id="t1", category=TaskCategory.STUDY, goal="Study", inputs={})
+    second = Task(id="t2", category=TaskCategory.STUDY, goal="Study", inputs={})
+
+    first.history.append("step")
+    assert first.history == ["step"]
+    assert second.history == []


### PR DESCRIPTION
## Summary
- define a Task model with category/priority/status enums and lightweight validation helpers
- add pytest coverage for valid construction, enum validation failures, and history default isolation
- update codex_progress milestone log to mark the task model complete and record test results

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfaa6ad8083309e5d3cebd326c1ac)