### PR TITLE
Add FastAPI /jarvis API and dependencies

### DIFF
--- a/docs/codex_progress.md
+++ b/docs/codex_progress.md
@@ -34,6 +34,7 @@
 - [x] Logging of evaluation outcomes and retry decisions
 
 ### M4: UI / API Connectivity
+- [x] FastAPI ベースの `/jarvis` API を追加し、uvicorn で起動可能 (例: `uvicorn jarvis_core.api:app --reload`)
 - [ ] HTTP or CLI wrapper callable from antigravity actions
 - [ ] Task ID–based progress query endpoint or CLI command
 - [ ] Auth/config plumbing separated from business logic (no hardcoded secrets)

--- a/jarvis_core/api.py
+++ b/jarvis_core/api.py
@@ -1,0 +1,23 @@
+"""Minimal FastAPI wrapper to expose Jarvis Core over HTTP."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from jarvis_core import run_jarvis
+
+app = FastAPI(title="Jarvis Core API", version="0.1.0")
+
+
+class JarvisRequest(BaseModel):
+    goal: str
+
+
+class JarvisResponse(BaseModel):
+    answer: str
+
+
+@app.post("/jarvis", response_model=JarvisResponse)
+def call_jarvis(req: JarvisRequest) -> JarvisResponse:
+    """Handle incoming Jarvis requests via HTTP."""
+    result = run_jarvis(req.goal)
+    return JarvisResponse(answer=result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ PyPDF2
 scikit-learn
 joblib
 pymupdf
+
+fastapi
+uvicorn[standard]
+pydantic

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from jarvis_core.api import app
+
+
+def test_jarvis_endpoint(monkeypatch):
+    client = TestClient(app)
+
+    monkeypatch.setattr("jarvis_core.api.run_jarvis", lambda goal: f"processed: {goal}")
+
+    response = client.post("/jarvis", json={"goal": "test goal"})
+
+    assert response.status_code == 200
+    assert response.json() == {"answer": "processed: test goal"}


### PR DESCRIPTION
## Summary
- add a minimal FastAPI application exposing the /jarvis endpoint that delegates to run_jarvis
- document the new HTTP entrypoint and uvicorn launch example and record progress in the M4 milestone log
- add API smoke coverage and project dependencies for FastAPI, uvicorn, and pydantic

## Testing
- python -m pytest tests/test_api_smoke.py *(fails: fastapi installation blocked by proxy in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4a922c408330a6218e3f5eecce77)