### PR TITLE
Add Cloudflare cron enqueuer and optional `API_TOKEN` Bearer auth for `/api/jobs`

### DIFF
--- a/cloudflare/cron-worker/README.md
+++ b/cloudflare/cron-worker/README.md
@@ -1,0 +1,47 @@
+# Jarvis Cron Enqueuer (Cloudflare Worker)
+
+Cloudflare Cron Triggers で定期的に Jarvis API の `POST /api/jobs` を叩き、
+`collect_and_ingest` ジョブを自動投入するための Worker です。
+
+## 前提
+
+- Cron は **UTC** 基準で実行されます（JST ではありません）。
+- `JARVIS_API_BASE` は末尾スラッシュなし推奨（Worker 側でも除去します）。
+- Jarvis API は **外部から HTTPS で到達可能**である必要があります（少なくとも `/api/jobs`）。
+
+## Cloudflare 側セットアップ（ローカルから）
+
+```bash
+cd cloudflare/cron-worker
+npm install
+# Vars
+npx wrangler secret put JARVIS_API_TOKEN
+# → token入力
+npx wrangler deploy
+```
+
+その後、Cloudflare Dashboard で `JARVIS_API_BASE` を本番 URL に設定するか、
+`wrangler.toml` の `vars` を編集して再 deploy してください。
+
+## API 側セットアップ（本番）
+
+- 環境変数 `API_TOKEN` を設定（Worker に入れた token と一致させる）
+- 例:
+  - `API_TOKEN=...`
+  - `REDIS_URL=...`（RQ/Redis を使うなら）
+- API 再起動
+
+## 動作確認（必須）
+
+1. Worker を `DRY_RUN=1` にして一度 cron 相当を手動実行（ログ確認）
+2. `DRY_RUN=0` に戻す
+3. 次の cron 時刻後、API ログに `/api/jobs` が来ていること
+4. UI の Jobs 一覧で `source=cloudflare_cron` / `target_name` が付いたジョブが増えること
+5. 完了後 CD73 で検索して結果が増えること
+
+## トラブルシュートのヒント
+
+- **投入は成功したが実行されない**: RQ worker が動いていない、Redis 接続が死んでいる等。
+  UI と API ログで検出できるようにしてください。
+- **API がプライベートネットワークのみ**: Worker から叩けません。
+  API は外部から HTTPS で到達可能にしてください。

--- a/cloudflare/cron-worker/src/index.ts
+++ b/cloudflare/cron-worker/src/index.ts
@@ -1,0 +1,120 @@
+type Target = {
+  name: string;
+  query: string;
+  max_results: number;
+  oa_only: boolean;
+  domain?: string;
+};
+
+type Env = {
+  JARVIS_API_BASE: string;
+  JARVIS_API_TOKEN: string;
+  DRY_RUN?: string;
+  TIMEZONE?: string;
+};
+
+const TARGETS: Target[] = [
+  {
+    name: "cd73_batch",
+    query: "CD73 OR NT5E",
+    max_results: 100,
+    oa_only: true,
+    domain: "immunology",
+  },
+  {
+    name: "cdh13_batch",
+    query: "CDH13 OR T-cadherin",
+    max_results: 100,
+    oa_only: true,
+    domain: "immunology",
+  },
+];
+
+// 簡易的に「朝/夜」を判定（Cronが2回/日という前提で十分）
+function computeSlot(nowUtc: Date): "slot_utc_0010" | "slot_utc_1210" | "slot_other" {
+  const h = nowUtc.getUTCHours();
+  const m = nowUtc.getUTCMinutes();
+  if (h === 0 && m === 10) return "slot_utc_0010";
+  if (h === 12 && m === 10) return "slot_utc_1210";
+  return "slot_other";
+}
+
+function yyyymmddUtc(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+async function postJob(env: Env, target: Target, dedupeKey: string): Promise<any> {
+  const url = `${env.JARVIS_API_BASE.replace(/\/+$/, "")}/api/jobs`;
+  const body = {
+    type: "collect_and_ingest",
+    payload: {
+      query: target.query,
+      max_results: target.max_results,
+      oa_only: target.oa_only,
+      domain: target.domain ?? null,
+      // API側で重複抑止に使えるように入れておく（未対応でも無害）
+      dedupe_key: dedupeKey,
+      source: "cloudflare_cron",
+      target_name: target.name,
+    },
+  };
+
+  // DRY_RUN
+  if ((env.DRY_RUN ?? "0") === "1") {
+    return { dry_run: true, url, body };
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${env.JARVIS_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  let json: any = null;
+  try { json = JSON.parse(text); } catch { /* ignore */ }
+
+  if (!res.ok) {
+    throw new Error(`POST /api/jobs failed: status=${res.status}, body=${text}`);
+  }
+
+  return json ?? { ok: true, raw: text };
+}
+
+export default {
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    const now = new Date();
+    const slot = computeSlot(now);
+    const date = yyyymmddUtc(now);
+
+    const results: any[] = [];
+
+    // ターゲットごとに投入。1件失敗しても他は続行。
+    for (const t of TARGETS) {
+      const dedupeKey = `${t.name}:${date}:${slot}`;
+      try {
+        const r = await postJob(env, t, dedupeKey);
+        results.push({ target: t.name, dedupe_key: dedupeKey, result: r });
+      } catch (e: any) {
+        results.push({ target: t.name, dedupe_key: dedupeKey, error: String(e?.message ?? e) });
+      }
+    }
+
+    // Cloudflareのログ（Workers dashboardで確認）
+    console.log(JSON.stringify({
+      kind: "jarvis_cron_enqueue",
+      utc: now.toISOString(),
+      slot,
+      timezone: env.TIMEZONE ?? "unknown",
+      api_base: env.JARVIS_API_BASE,
+      dry_run: (env.DRY_RUN ?? "0") === "1",
+      results,
+    }));
+  },
+};

--- a/cloudflare/cron-worker/wrangler.toml
+++ b/cloudflare/cron-worker/wrangler.toml
@@ -1,0 +1,15 @@
+name = "jarvis-cron-enqueuer"
+main = "src/index.ts"
+compatibility_date = "2025-12-01"
+
+[vars]
+# 例: "https://your-api.example.com"
+JARVIS_API_BASE = "CHANGE_ME"
+DRY_RUN = "0"
+TIMEZONE = "Asia/Tokyo"
+
+# Cron Triggers (UTC)
+# 00:10 UTC = 09:10 JST
+# 12:10 UTC = 21:10 JST
+[triggers]
+crons = ["10 0 * * *", "10 12 * * *"]


### PR DESCRIPTION
### Motivation
- Add a Cloudflare Worker that periodically enqueues `collect_and_ingest` jobs to the Jarvis API so scheduled collection runs can be automated.  
- Prevent duplicate submissions for the same target/slot by including a `dedupe_key` in the job payload.  
- Protect job submission from arbitrary external callers by requiring a Bearer token when `API_TOKEN` is configured.  
- Keep local development unbroken by making the auth check conditional on the presence of `API_TOKEN`.

### Description
- Add Cloudflare worker config `cloudflare/cron-worker/wrangler.toml` with cron triggers and vars including `JARVIS_API_BASE`, `DRY_RUN`, and `TIMEZONE`.  
- Add worker implementation `cloudflare/cron-worker/src/index.ts` which defines fixed `TARGETS`, computes a `dedupe_key` per target+date+slot, supports `DRY_RUN`, and POSTs to `POST /api/jobs` with `Authorization: Bearer <token>`.  
- Add `cloudflare/cron-worker/README.md` with setup, timezone, trailing-slash, and verification guidance and example `wrangler` commands.  
- Update `jarvis_web/app.py` to read `API_TOKEN`, add `verify_api_token` (auth required only if `API_TOKEN` is set), and wire `/api/jobs` to use `Depends(verify_api_token)` so the endpoint is protected when configured.

### Testing
- No automated tests were executed as part of this change.  
- Packaged files were added and committed to the repository successfully.  
- The worker includes a `DRY_RUN=1` mode to manually verify requests without enqueuing jobs.  
- Manual verification steps are documented in `cloudflare/cron-worker/README.md` for deploying and testing the cron enqueuer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951fcf50cfc8330a7243000647ecf20)