### PR TITLE
Add writing draft generation (research plan / thesis / slides) with DOCX/PPTX export and API/UI integration

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1004,8 +1004,19 @@
                 ).join('')}
                     </table>
 
+                    <h3>✍️ Drafts</h3>
+                    <div style="display: flex; flex-wrap: wrap; gap: 10px; margin: 10px 0;">
+                        <button class="btn btn-primary" onclick="generateWriting('${runId}')">Generate drafts</button>
+                        <button class="btn btn-secondary" onclick="downloadWriting('${runId}', 'writing/research_plan_draft.docx')">Download research_plan.docx</button>
+                        <button class="btn btn-secondary" onclick="downloadWriting('${runId}', 'writing/thesis_draft.docx')">Download thesis_draft.docx</button>
+                        <button class="btn btn-secondary" onclick="downloadWriting('${runId}', 'writing/slides_draft.pptx')">Download slides_draft.pptx</button>
+                        <button class="btn btn-secondary" onclick="downloadPackage('${runId}')">Download all package.zip</button>
+                    </div>
+                    <div id="writing-files" style="margin-bottom: 20px; color: var(--text-secondary);">Checking writing outputs...</div>
+
                     ${run.report ? `<h3>📝 Report</h3><pre style="max-height: 300px; overflow: auto; background: var(--bg-primary); padding: 15px; border-radius: 8px; white-space: pre-wrap;">${escapeHtml(run.report)}</pre>` : ''}
                 `;
+                loadWritingFiles(runId);
             } catch (e) {
                 body.innerHTML = `<p style="color: var(--danger);">読み込みエラー: ${e.message}</p>`;
             }
@@ -1029,6 +1040,60 @@
         function refreshAll() {
             loadRuns();
             showToast('更新しました');
+        }
+
+        async function generateWriting(runId) {
+            try {
+                const res = await fetch(`${API_BASE}/api/writing/generate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        run_id: runId,
+                        outputs: {
+                            research_plan: true,
+                            thesis: true,
+                            slides: true,
+                            docx: true,
+                            pptx: true
+                        }
+                    })
+                });
+                const data = await res.json();
+                if (data.job_id) {
+                    startJobPolling(data.job_id);
+                    showToast('Writing generation started', 'info');
+                } else {
+                    showToast('Writing generation failed', 'danger');
+                }
+            } catch (e) {
+                showToast(`Writing generation error: ${e.message}`, 'danger');
+            }
+        }
+
+        async function loadWritingFiles(runId) {
+            const container = document.getElementById('writing-files');
+            if (!container) return;
+            try {
+                const res = await fetch(`${API_BASE}/api/writing/run/${runId}/files`);
+                const data = await res.json();
+                if (!data.files || data.files.length === 0) {
+                    container.textContent = 'No writing outputs generated yet.';
+                    return;
+                }
+                container.innerHTML = data.files
+                    .map(file => `${file.name} (${file.size} bytes)`)
+                    .join('<br>');
+            } catch (e) {
+                container.textContent = `Failed to load writing outputs: ${e.message}`;
+            }
+        }
+
+        function downloadWriting(runId, path) {
+            window.open(`${API_BASE}/api/writing/run/${runId}/download?path=${encodeURIComponent(path)}`, '_blank');
+        }
+
+        function downloadPackage(runId) {
+            window.open(`${API_BASE}/api/export/run/${runId}/package`, '_blank');
         }
 
         function startJobPolling(jobId) {

--- a/jarvis_core/export/__init__.py
+++ b/jarvis_core/export/__init__.py
@@ -1,0 +1,11 @@
+"""Export utilities for writing outputs."""
+
+from .docx_builder import build_docx_from_markdown
+from .pptx_builder import build_pptx_from_slides
+from .package_builder import build_run_package
+
+__all__ = [
+    "build_docx_from_markdown",
+    "build_pptx_from_slides",
+    "build_run_package",
+]

--- a/jarvis_core/export/docx_builder.py
+++ b/jarvis_core/export/docx_builder.py
@@ -1,0 +1,40 @@
+"""DOCX export helpers for writing drafts."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from docx import Document
+    DOCX_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    DOCX_AVAILABLE = False
+    Document = None
+
+
+def _add_markdown_line(document: "Document", line: str) -> None:
+    if line.startswith("# "):
+        document.add_heading(line[2:].strip(), level=1)
+    elif line.startswith("## "):
+        document.add_heading(line[3:].strip(), level=2)
+    elif line.startswith("### "):
+        document.add_heading(line[4:].strip(), level=3)
+    elif line.startswith("- "):
+        document.add_paragraph(line[2:].strip(), style="List Bullet")
+    else:
+        document.add_paragraph(line)
+
+
+def build_docx_from_markdown(markdown: str, output_path: Path) -> Path:
+    if not DOCX_AVAILABLE:
+        raise RuntimeError("python-docx is not installed. Please add python-docx to requirements.")
+
+    document = Document()
+    for line in markdown.splitlines():
+        if not line.strip():
+            continue
+        _add_markdown_line(document, line)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    document.save(output_path)
+    return output_path

--- a/jarvis_core/export/package_builder.py
+++ b/jarvis_core/export/package_builder.py
@@ -1,0 +1,24 @@
+"""Package builder for run outputs including writing drafts."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+
+def build_run_package(run_id: str, output_path: Optional[Path] = None) -> Path:
+    run_dir = Path("data/runs") / run_id
+    if not run_dir.exists():
+        raise FileNotFoundError(f"Run directory not found: {run_dir}")
+
+    if output_path is None:
+        output_path = run_dir / "package.zip"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for path in run_dir.rglob("*"):
+            if path.is_file() and path != output_path:
+                zipf.write(path, path.relative_to(run_dir))
+
+    return output_path

--- a/jarvis_core/export/pptx_builder.py
+++ b/jarvis_core/export/pptx_builder.py
@@ -1,0 +1,144 @@
+"""PPTX export helpers for writing drafts."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+try:
+    from pptx import Presentation
+    from pptx.util import Inches, Pt
+    PPTX_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    PPTX_AVAILABLE = False
+    Presentation = None
+    Inches = None
+    Pt = None
+
+from ..writing.utils import load_overview
+from ..writing.outline_builder import ClaimDatum
+
+
+SLIDE_WIDTH = Inches(10) if Inches else None
+SLIDE_HEIGHT = Inches(7.5) if Inches else None
+
+
+def _slide_footer(slide, text: str) -> None:
+    textbox = slide.shapes.add_textbox(Inches(0.5), Inches(6.8), Inches(9), Inches(0.4))
+    text_frame = textbox.text_frame
+    text_frame.clear()
+    p = text_frame.paragraphs[0]
+    run = p.add_run()
+    run.text = text
+    run.font.size = Pt(10)
+
+
+def _add_bullets(presentation: "Presentation", title: str, bullets: List[str]):
+    layout = presentation.slide_layouts[1]
+    content_slide = presentation.slides.add_slide(layout)
+    content_slide.shapes.title.text = title
+    body = content_slide.shapes.placeholders[1].text_frame
+    body.clear()
+    for idx, bullet in enumerate(bullets):
+        p = body.paragraphs[0] if idx == 0 else body.add_paragraph()
+        p.text = bullet
+        p.level = 0
+    return content_slide
+
+
+def _evidence_footer_text(claim: ClaimDatum | None) -> str:
+    if not claim or not claim.evidence:
+        return "Evidence: unknown"
+    ev = claim.evidence[0]
+    return f"Evidence: {ev.paper_id}/{ev.chunk_id}"
+
+
+def build_pptx_from_slides(run_dir: Path, claims: List[ClaimDatum], output_path: Path) -> Path:
+    if not PPTX_AVAILABLE:
+        raise RuntimeError("python-pptx is not installed. Please add python-pptx to requirements.")
+
+    presentation = Presentation()
+    overview = load_overview(run_dir)
+    ordered = claims
+    top_claim = ordered[0] if ordered else None
+    second_claim = ordered[1] if len(ordered) > 1 else None
+
+    title_slide_layout = presentation.slide_layouts[0]
+    slide = presentation.slides.add_slide(title_slide_layout)
+    slide.shapes.title.text = "研究テーマ"
+    slide.placeholders[1].text = "所属 / 氏名"
+    _slide_footer(slide, _evidence_footer_text(top_claim))
+
+    background_bullets = [
+        (overview.split("\n")[0].strip() if overview else "Background summary placeholder."),
+        "図プレースホルダ: 概念図を挿入してください。",
+    ]
+    background_slide = _add_bullets(presentation, "Background", background_bullets)
+    _slide_footer(background_slide, _evidence_footer_text(top_claim))
+
+    gap_bullets = [
+        f"Fact: {second_claim.text if second_claim else 'Gap placeholder'}",
+        "Interpretation: 既存研究の不足点を整理する。",
+    ]
+    gap_slide = _add_bullets(presentation, "Gap & Hypothesis", gap_bullets)
+    _slide_footer(gap_slide, _evidence_footer_text(second_claim or top_claim))
+
+    aims_bullets = [
+        f"Aim 1: {top_claim.text if top_claim else 'Aim placeholder'}",
+        "Aim 2: [[YOUR_DATA_HERE]]",
+        "Aim 3: [[YOUR_DATA_HERE]]",
+    ]
+    aims_slide = _add_bullets(presentation, "Aim / Objective", aims_bullets)
+    _slide_footer(aims_slide, _evidence_footer_text(top_claim))
+
+    methods_bullets = [
+        "Fact: 既存の方法概要を記述。",
+        "Interpretation: 方法の意図と利点を説明。",
+        "模式図プレースホルダ: 実験フローを挿入。",
+    ]
+    methods_slide = _add_bullets(presentation, "Methods overview", methods_bullets)
+    _slide_footer(methods_slide, _evidence_footer_text(top_claim))
+
+    result1_claim = ordered[0] if ordered else None
+    result2_claim = ordered[1] if len(ordered) > 1 else None
+
+    result1_bullets = [
+        f"Fact: {result1_claim.text if result1_claim else 'Result placeholder'}",
+        "Interpretation: 結果の示唆を記述。",
+        "図プレースホルダ: 結果図を挿入。",
+    ]
+    result1_slide = _add_bullets(presentation, "Key Result 1", result1_bullets)
+    _slide_footer(result1_slide, _evidence_footer_text(result1_claim))
+
+    result2_bullets = [
+        f"Fact: {result2_claim.text if result2_claim else 'Result placeholder'}",
+        "Interpretation: 結果の示唆を記述。",
+        "図プレースホルダ: 結果図を挿入。",
+    ]
+    result2_slide = _add_bullets(presentation, "Key Result 2", result2_bullets)
+    _slide_footer(result2_slide, _evidence_footer_text(result2_claim))
+
+    discussion_bullets = [
+        "Fact: 結果の再掲。",
+        "Interpretation: 限界と今後の課題を整理。",
+        "Limitations: [[LAB_TERMS_CHECK]]",
+    ]
+    discussion_slide = _add_bullets(presentation, "Discussion", discussion_bullets)
+    _slide_footer(discussion_slide, _evidence_footer_text(top_claim))
+
+    future_bullets = [
+        "Next experiment: [[YOUR_DATA_HERE]]",
+        "New hypothesis: [[YOUR_DATA_HERE]]",
+    ]
+    future_slide = _add_bullets(presentation, "Future work", future_bullets)
+    _slide_footer(future_slide, _evidence_footer_text(top_claim))
+
+    takehome_bullets = [
+        f"Fact: {top_claim.text if top_claim else 'Take-home placeholder'}",
+        "Interpretation: 研究の主要な学術的意義。",
+    ]
+    takehome_slide = _add_bullets(presentation, "Take-home message", takehome_bullets)
+    _slide_footer(takehome_slide, _evidence_footer_text(top_claim))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    presentation.save(output_path)
+    return output_path

--- a/jarvis_core/writing/__init__.py
+++ b/jarvis_core/writing/__init__.py
@@ -1,0 +1,5 @@
+"""Writing draft generation utilities."""
+
+from .draft_generator import generate_writing_outputs
+
+__all__ = ["generate_writing_outputs"]

--- a/jarvis_core/writing/citation_formatter.py
+++ b/jarvis_core/writing/citation_formatter.py
@@ -1,0 +1,42 @@
+"""Evidence locator formatting utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class EvidenceLocator:
+    """Normalized evidence locator."""
+
+    paper_id: str
+    chunk_id: str
+    section: str
+    paragraph: str
+    sentence: str
+    weak: bool = False
+
+
+def _safe(value: Optional[object], fallback: str = "unknown") -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text if text else fallback
+
+
+def format_evidence_locator(evidence_items: Iterable[EvidenceLocator]) -> str:
+    """Format evidence locator string for paragraph suffix."""
+    items = list(evidence_items)
+    if not items:
+        return "【根拠: unknown】"
+
+    parts: List[str] = []
+    for item in items[:3]:
+        parts.append(
+            f"{_safe(item.paper_id)}, {_safe(item.chunk_id)}, {_safe(item.section)} ¶ {_safe(item.paragraph)} {_safe(item.sentence)}"
+        )
+    return f"【根拠: {'; '.join(parts)}】"
+
+
+def has_weak_evidence(evidence_items: Iterable[EvidenceLocator]) -> bool:
+    return any(item.weak for item in evidence_items)

--- a/jarvis_core/writing/draft_generator.py
+++ b/jarvis_core/writing/draft_generator.py
@@ -1,0 +1,253 @@
+"""Draft generation for research plan, thesis, and slides."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .citation_formatter import EvidenceLocator
+from .outline_builder import (
+    ClaimDatum,
+    Section,
+    build_research_plan_sections,
+    build_thesis_draft_sections,
+    build_thesis_outline_sections,
+)
+from ..export.docx_builder import build_docx_from_markdown
+from ..export.pptx_builder import build_pptx_from_slides
+from .utils import load_overview
+
+
+TEMPLATE_VERSION = "p5-v1"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+
+def _normalize_evidence(item: Dict[str, Any]) -> EvidenceLocator:
+    return EvidenceLocator(
+        paper_id=str(item.get("paper_id") or item.get("paper") or "unknown"),
+        chunk_id=str(item.get("chunk_id") or item.get("chunk") or "unknown"),
+        section=str(item.get("section") or item.get("section_title") or "unknown"),
+        paragraph=str(item.get("paragraph") or item.get("paragraph_id") or "unknown"),
+        sentence=str(item.get("sentence") or item.get("sentence_id") or "unknown"),
+        weak=bool(item.get("weak_evidence") or item.get("weak") or False),
+    )
+
+
+def _extract_evidence(raw: Any) -> List[EvidenceLocator]:
+    if not raw:
+        return []
+    evidence_items: List[EvidenceLocator] = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, dict):
+                evidence_items.append(_normalize_evidence(entry))
+            else:
+                evidence_items.append(
+                    EvidenceLocator(
+                        paper_id="unknown",
+                        chunk_id=str(entry),
+                        section="unknown",
+                        paragraph="unknown",
+                        sentence="unknown",
+                        weak=False,
+                    )
+                )
+    elif isinstance(raw, dict):
+        evidence_items.append(_normalize_evidence(raw))
+    else:
+        evidence_items.append(
+            EvidenceLocator(
+                paper_id="unknown",
+                chunk_id=str(raw),
+                section="unknown",
+                paragraph="unknown",
+                sentence="unknown",
+                weak=False,
+            )
+        )
+    return evidence_items
+
+
+def load_claims(run_dir: Path) -> List[ClaimDatum]:
+    claims_dir = run_dir / "claims"
+    claim_files = sorted(claims_dir.glob("*.claims.jsonl")) if claims_dir.exists() else []
+    claims: List[ClaimDatum] = []
+
+    for path in claim_files:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                data = json.loads(line)
+                text = data.get("claim") or data.get("text") or data.get("statement") or ""
+                if not text:
+                    continue
+                evidence_raw = data.get("evidence") or data.get("citations") or data.get("citation_details")
+                evidence = _extract_evidence(evidence_raw)
+                weak = bool(data.get("weak_evidence") or data.get("weak"))
+                score = data.get("score") or data.get("rank_score")
+                claims.append(
+                    ClaimDatum(
+                        text=text,
+                        evidence=evidence,
+                        weak=weak,
+                        score=float(score) if score is not None else None,
+                        claim_id=data.get("claim_id") or data.get("id"),
+                    )
+                )
+    return claims
+
+
+def _load_references(run_dir: Path, claims: Iterable[ClaimDatum]) -> List[str]:
+    research_rank_path = run_dir / "research_rank.json"
+    references: List[str] = []
+    if research_rank_path.exists():
+        try:
+            data = _safe_read_json(research_rank_path)
+            items = data.get("papers") or data.get("ranked") or data.get("items") or []
+            for item in items:
+                if isinstance(item, dict):
+                    paper_id = item.get("paper_id") or item.get("id") or "unknown"
+                    title = item.get("title") or ""
+                    references.append(f"{paper_id}: {title}" if title else str(paper_id))
+        except Exception:
+            references = []
+
+    if not references:
+        paper_ids = {ev.paper_id for claim in claims for ev in claim.evidence if ev.paper_id}
+        references = sorted(paper_ids) if paper_ids else []
+    return references
+
+
+def _sections_to_markdown(sections: Iterable[Section]) -> str:
+    lines: List[str] = []
+    for section in sections:
+        lines.append(f"## {section.title}")
+        lines.append("")
+        for paragraph in section.paragraphs:
+            if paragraph.startswith("- "):
+                lines.append(paragraph)
+            else:
+                lines.append(paragraph)
+                lines.append("")
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _build_metadata_header(run_id: str) -> str:
+    return (
+        f"Generated from run_id={run_id}, template_version={TEMPLATE_VERSION}, generated_at={_now()}\n\n"
+    )
+
+
+def generate_markdown_research_plan(run_dir: Path, claims: List[ClaimDatum]) -> str:
+    overview_text = load_overview(run_dir)
+    references = _load_references(run_dir, claims)
+    sections = build_research_plan_sections(claims, overview_text, references)
+    return "# Research Plan Draft\n\n" + _build_metadata_header(run_dir.name) + _sections_to_markdown(sections)
+
+
+def generate_markdown_thesis_outline(run_dir: Path, claims: List[ClaimDatum]) -> str:
+    references = _load_references(run_dir, claims)
+    sections = build_thesis_outline_sections(claims, references)
+    return "# Thesis Outline\n\n" + _build_metadata_header(run_dir.name) + _sections_to_markdown(sections)
+
+
+def generate_markdown_thesis_draft(run_dir: Path, claims: List[ClaimDatum]) -> str:
+    references = _load_references(run_dir, claims)
+    sections = build_thesis_draft_sections(claims, references)
+    return "# Thesis Draft\n\n" + _build_metadata_header(run_dir.name) + _sections_to_markdown(sections)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_readme(run_dir: Path) -> None:
+    writing_dir = run_dir / "writing"
+    readme_path = writing_dir / "README.md"
+    content = (
+        "# Writing Outputs\n\n"
+        "This folder contains auto-generated drafts for the research plan, thesis, and slides.\n"
+        "- Markdown files are editable drafts with evidence locators appended per paragraph.\n"
+        "- DOCX files are generated from the Markdown drafts for word processing.\n"
+        "- PPTX file is a slide draft with placeholders for figures and lab-specific details.\n\n"
+        f"Generated from run_id={run_dir.name}, template_version={TEMPLATE_VERSION}, generated_at={_now()}\n"
+    )
+    _write_text(readme_path, content)
+
+
+def _update_manifest(run_dir: Path, outputs: List[str]) -> None:
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        return
+    manifest = _safe_read_json(manifest_path)
+    manifest["writing_template_version"] = TEMPLATE_VERSION
+    manifest["writing_generated_at"] = _now()
+    manifest["writing_outputs"] = outputs
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+
+
+def generate_writing_outputs(run_id: str, outputs: Dict[str, bool]) -> Dict[str, Any]:
+    run_dir = Path("data/runs") / run_id
+    if not run_dir.exists():
+        raise FileNotFoundError(f"Run directory not found: {run_dir}")
+
+    claims = load_claims(run_dir)
+    writing_dir = run_dir / "writing"
+    writing_dir.mkdir(parents=True, exist_ok=True)
+
+    generated: List[str] = []
+
+    if outputs.get("research_plan"):
+        research_md = generate_markdown_research_plan(run_dir, claims)
+        research_md_path = writing_dir / "research_plan_draft.md"
+        _write_text(research_md_path, research_md)
+        generated.append(str(research_md_path.relative_to(run_dir)))
+
+        if outputs.get("docx"):
+            docx_path = writing_dir / "research_plan_draft.docx"
+            build_docx_from_markdown(research_md, docx_path)
+            generated.append(str(docx_path.relative_to(run_dir)))
+
+    if outputs.get("thesis"):
+        outline_md = generate_markdown_thesis_outline(run_dir, claims)
+        outline_path = writing_dir / "thesis_outline.md"
+        _write_text(outline_path, outline_md)
+        generated.append(str(outline_path.relative_to(run_dir)))
+
+        thesis_md = generate_markdown_thesis_draft(run_dir, claims)
+        thesis_path = writing_dir / "thesis_draft.md"
+        _write_text(thesis_path, thesis_md)
+        generated.append(str(thesis_path.relative_to(run_dir)))
+
+        if outputs.get("docx"):
+            thesis_docx_path = writing_dir / "thesis_draft.docx"
+            build_docx_from_markdown(thesis_md, thesis_docx_path)
+            generated.append(str(thesis_docx_path.relative_to(run_dir)))
+
+    if outputs.get("slides") and outputs.get("pptx"):
+        slides_path = writing_dir / "slides_draft.pptx"
+        build_pptx_from_slides(run_dir, claims, slides_path)
+        generated.append(str(slides_path.relative_to(run_dir)))
+
+    _write_readme(run_dir)
+    generated.append("writing/README.md")
+
+    _update_manifest(run_dir, generated)
+
+    return {"run_id": run_id, "outputs": generated, "template_version": TEMPLATE_VERSION}

--- a/jarvis_core/writing/outline_builder.py
+++ b/jarvis_core/writing/outline_builder.py
@@ -1,0 +1,199 @@
+"""Outline and draft structure builder for writing outputs."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .citation_formatter import EvidenceLocator, format_evidence_locator, has_weak_evidence
+
+
+@dataclass
+class ClaimDatum:
+    """Normalized claim information for drafting."""
+
+    text: str
+    evidence: List[EvidenceLocator]
+    weak: bool = False
+    score: Optional[float] = None
+    claim_id: Optional[str] = None
+
+
+@dataclass
+class Section:
+    """Draft section container."""
+
+    title: str
+    paragraphs: List[str]
+
+
+def load_template(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _sorted_claims(claims: Iterable[ClaimDatum]) -> List[ClaimDatum]:
+    claims_list = list(claims)
+    scored = [c for c in claims_list if c.score is not None]
+    if scored:
+        return sorted(claims_list, key=lambda c: c.score or 0, reverse=True)
+    return claims_list
+
+
+def _paragraph_from_claim(claim: ClaimDatum, prefix: str | None = None) -> str:
+    text = claim.text.strip()
+    if prefix:
+        text = f"{prefix}{text}"
+    locator = format_evidence_locator(claim.evidence)
+    weak_note = "（推測です）" if claim.weak or has_weak_evidence(claim.evidence) else ""
+    return f"{text} {locator}{weak_note}".strip()
+
+
+def _fallback_paragraph(label: str) -> str:
+    locator = format_evidence_locator([])
+    return f"{label} {locator}"
+
+
+def build_research_plan_sections(
+    claims: Iterable[ClaimDatum],
+    overview_text: str,
+    references: List[str],
+) -> List[Section]:
+    ordered = _sorted_claims(claims)
+    top_claim = ordered[0] if ordered else None
+
+    overview_paragraphs = [p.strip() for p in overview_text.split("\n\n") if p.strip()]
+    if overview_paragraphs and top_claim:
+        background_paragraphs = [
+            f"{overview_paragraphs[0]} {format_evidence_locator(top_claim.evidence)}"
+            f"{'（推測です）' if top_claim.weak else ''}"
+        ]
+    elif top_claim:
+        background_paragraphs = [_paragraph_from_claim(top_claim, prefix="背景: ")]
+    else:
+        background_paragraphs = [_fallback_paragraph("背景情報は追加予定です。")]
+
+    gap_claim = ordered[1] if len(ordered) > 1 else top_claim
+    gap_paragraphs = (
+        [_paragraph_from_claim(gap_claim, prefix="未解決課題: ")] if gap_claim else [_fallback_paragraph("未解決課題を整理してください。")]
+    )
+
+    hypothesis_claim = ordered[2] if len(ordered) > 2 else top_claim
+    hypothesis_paragraphs = (
+        [_paragraph_from_claim(hypothesis_claim, prefix="仮説: ")] if hypothesis_claim else [_fallback_paragraph("仮説を設定してください。")]
+    )
+
+    aim_paragraphs: List[str] = []
+    for idx in range(3):
+        if idx < len(ordered):
+            aim_paragraphs.append(_paragraph_from_claim(ordered[idx], prefix=f"Aim {idx + 1}: "))
+        else:
+            aim_paragraphs.append(_fallback_paragraph(f"Aim {idx + 1}: [[YOUR_DATA_HERE]]"))
+
+    approach_paragraphs: List[str] = []
+    for idx in range(3):
+        claim = ordered[idx] if idx < len(ordered) else top_claim
+        if claim:
+            approach_paragraphs.append(
+                _paragraph_from_claim(claim, prefix=f"Aim {idx + 1}の方法: [[YOUR_DATA_HERE]] ")
+            )
+        else:
+            approach_paragraphs.append(_fallback_paragraph(f"Aim {idx + 1}の方法: [[YOUR_DATA_HERE]]"))
+
+    expected_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="期待される結果: ")]
+        if top_claim
+        else [_fallback_paragraph("期待される結果を記述してください。")]
+    )
+
+    risk_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="リスク: [[LAB_TERMS_CHECK]] ")]
+        if top_claim
+        else [_fallback_paragraph("リスクと代替案を追記してください。")]
+    )
+
+    impact_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="インパクト: ")]
+        if top_claim
+        else [_fallback_paragraph("インパクトを記述してください。")]
+    )
+
+    reference_paragraphs = [
+        f"- {ref}" for ref in references
+    ] or ["- [[REFERENCES_PLACEHOLDER]]"]
+
+    return [
+        Section("背景 (Background)", background_paragraphs),
+        Section("未解決課題 (Gap)", gap_paragraphs),
+        Section("仮説 (Hypothesis)", hypothesis_paragraphs),
+        Section("目的 (Aims)", aim_paragraphs),
+        Section("研究方法 (Approach)", approach_paragraphs),
+        Section("期待される結果と解釈 (Expected outcomes)", expected_paragraphs),
+        Section("リスクと代替案 (Risks & Alternatives)", risk_paragraphs),
+        Section("インパクト (Impact)", impact_paragraphs),
+        Section("参考文献 (References)", reference_paragraphs),
+    ]
+
+
+def build_thesis_outline_sections(
+    claims: Iterable[ClaimDatum],
+    references: List[str],
+) -> List[Section]:
+    ordered = _sorted_claims(claims)
+    top_claim = ordered[0] if ordered else None
+
+    abstract_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="要旨: ")] if top_claim else [_fallback_paragraph("要旨を記述してください。")]
+    )
+    background_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="背景: ")] if top_claim else [_fallback_paragraph("背景を記述してください。")]
+    )
+    objectives_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="目的: ")] if top_claim else [_fallback_paragraph("目的を記述してください。")]
+    )
+    methods_paragraphs = [
+        _fallback_paragraph("[[YOUR_DATA_HERE]] 実験条件・図番号・統計を記述"),
+        _fallback_paragraph("[[FIGURE_PLACEHOLDER]] 図の挿入位置を記述"),
+        _fallback_paragraph("[[LAB_TERMS_CHECK]] ラボ用語整合の確認"),
+    ]
+
+    results_paragraphs: List[str] = []
+    for idx, claim in enumerate(ordered[:5], start=1):
+        results_paragraphs.append(_paragraph_from_claim(claim, prefix=f"結果{idx}: "))
+    if not results_paragraphs:
+        results_paragraphs.append(_fallback_paragraph("結果を記述してください。"))
+
+    discussion_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="考察: ")] if top_claim else [_fallback_paragraph("考察を記述してください。")]
+    )
+    conclusion_paragraphs = (
+        [_paragraph_from_claim(top_claim, prefix="結論: ")] if top_claim else [_fallback_paragraph("結論を記述してください。")]
+    )
+
+    reference_paragraphs = [f"- {ref}" for ref in references] or ["- [[REFERENCES_PLACEHOLDER]]"]
+
+    return [
+        Section("要旨 (Abstract)", abstract_paragraphs),
+        Section("背景 (Background)", background_paragraphs),
+        Section("目的 (Objectives)", objectives_paragraphs),
+        Section("方法 (Methods)", methods_paragraphs),
+        Section("結果 (Results)", results_paragraphs),
+        Section("考察 (Discussion)", discussion_paragraphs),
+        Section("結論 (Conclusion)", conclusion_paragraphs),
+        Section("参考文献 (References)", reference_paragraphs),
+    ]
+
+
+def build_thesis_draft_sections(
+    claims: Iterable[ClaimDatum],
+    references: List[str],
+) -> List[Section]:
+    sections = build_thesis_outline_sections(claims, references)
+    expanded_sections: List[Section] = []
+    for section in sections:
+        if section.title.startswith("結果"):
+            expanded_sections.append(section)
+            continue
+        expanded_sections.append(section)
+    return expanded_sections

--- a/jarvis_core/writing/templates/research_plan_template.json
+++ b/jarvis_core/writing/templates/research_plan_template.json
@@ -1,0 +1,14 @@
+{
+  "template_version": "p5-v1",
+  "sections": [
+    {"key": "background", "title": "背景 (Background)"},
+    {"key": "gap", "title": "未解決課題 (Gap)"},
+    {"key": "hypothesis", "title": "仮説 (Hypothesis)"},
+    {"key": "aims", "title": "目的 (Aims)"},
+    {"key": "approach", "title": "研究方法 (Approach)"},
+    {"key": "expected", "title": "期待される結果と解釈 (Expected outcomes)"},
+    {"key": "risks", "title": "リスクと代替案 (Risks & Alternatives)"},
+    {"key": "impact", "title": "インパクト (Impact)"},
+    {"key": "references", "title": "参考文献 (References)"}
+  ]
+}

--- a/jarvis_core/writing/templates/slides_template.json
+++ b/jarvis_core/writing/templates/slides_template.json
@@ -1,0 +1,15 @@
+{
+  "template_version": "p5-v1",
+  "slides": [
+    {"key": "title", "title": "Title"},
+    {"key": "background", "title": "Background"},
+    {"key": "gap_hypothesis", "title": "Gap & Hypothesis"},
+    {"key": "aims", "title": "Aim / Objective"},
+    {"key": "methods", "title": "Methods overview"},
+    {"key": "result1", "title": "Key Result 1"},
+    {"key": "result2", "title": "Key Result 2"},
+    {"key": "discussion", "title": "Discussion"},
+    {"key": "future", "title": "Future work"},
+    {"key": "takehome", "title": "Take-home message"}
+  ]
+}

--- a/jarvis_core/writing/templates/thesis_template.json
+++ b/jarvis_core/writing/templates/thesis_template.json
@@ -1,0 +1,13 @@
+{
+  "template_version": "p5-v1",
+  "sections": [
+    {"key": "abstract", "title": "要旨 (Abstract)"},
+    {"key": "background", "title": "背景 (Background)"},
+    {"key": "objectives", "title": "目的 (Objectives)"},
+    {"key": "methods", "title": "方法 (Methods)"},
+    {"key": "results", "title": "結果 (Results)"},
+    {"key": "discussion", "title": "考察 (Discussion)"},
+    {"key": "conclusion", "title": "結論 (Conclusion)"},
+    {"key": "references", "title": "参考文献 (References)"}
+  ]
+}

--- a/jarvis_core/writing/utils.py
+++ b/jarvis_core/writing/utils.py
@@ -1,0 +1,11 @@
+"""Shared utilities for writing generation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_overview(run_dir: Path) -> str:
+    overview_path = run_dir / "notes" / "00_RUN_OVERVIEW.md"
+    if overview_path.exists():
+        return overview_path.read_text(encoding="utf-8")
+    return ""

--- a/jarvis_web/routes/__init__.py
+++ b/jarvis_web/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/jarvis_web/routes/writing.py
+++ b/jarvis_web/routes/writing.py
@@ -1,0 +1,62 @@
+"""Routes for writing draft generation."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from jarvis_web import jobs
+from jarvis_web.job_runner import run_job
+
+
+router = APIRouter()
+
+
+class WritingOutputs(BaseModel):
+    research_plan: bool = True
+    thesis: bool = True
+    slides: bool = True
+    docx: bool = True
+    pptx: bool = True
+
+
+class WritingRequest(BaseModel):
+    run_id: str
+    outputs: WritingOutputs
+
+
+@router.post("/api/writing/generate")
+async def generate_writing(request: WritingRequest):
+    payload = {
+        "run_id": request.run_id,
+        "outputs": request.outputs.dict(),
+    }
+    job = jobs.create_job("writing_generate", payload)
+    jobs.run_in_background(job["job_id"], lambda: run_job(job["job_id"]))
+    return {"job_id": job["job_id"], "status": job["status"]}
+
+
+@router.get("/api/writing/run/{run_id}/files")
+async def list_writing_files(run_id: str):
+    writing_dir = Path("data/runs") / run_id / "writing"
+    if not writing_dir.exists():
+        return {"files": []}
+    files = []
+    for path in writing_dir.iterdir():
+        if path.is_file():
+            files.append({"name": path.name, "size": path.stat().st_size})
+    return {"files": files}
+
+
+@router.get("/api/writing/run/{run_id}/download")
+async def download_writing_file(run_id: str, path: str):
+    run_dir = Path("data/runs") / run_id
+    target = (run_dir / path).resolve()
+    if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    if run_dir.resolve() not in target.parents:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return FileResponse(target)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ PyPDF2
 scikit-learn
 joblib
 pymupdf
+python-docx
+python-pptx


### PR DESCRIPTION
### Motivation

- Provide P5: automated generation of research-plan, thesis drafts and slide drafts from existing run artifacts with evidence locators.
- Produce editable outputs in both Markdown and office formats and include them in run packages for easy download and reproducibility.
- Expose generation as an asynchronous job and make artifacts downloadable from the web UI and API.
- Record `writing_template_version` in the run `manifest.json` for reproducibility.

### Description

- Added writing generation modules under `jarvis_core/writing/`: `outline_builder.py`, `draft_generator.py`, `citation_formatter.py`, `utils.py`, and JSON templates in `writing/templates/` that assemble sections and attach evidence locators.
- Implemented export helpers under `jarvis_core/export/`: `docx_builder.py`, `pptx_builder.py`, and `package_builder.py`, and re-exported them in `jarvis_core/export/__init__.py`, and added `python-docx`/`python-pptx` to `requirements.txt`.
- Integrated server/API and job flow: new FastAPI routes in `jarvis_web/routes/writing.py`, included router in `jarvis_web/app.py`, added `writing_generate` job handling in `jarvis_web/job_runner.py`, and added run package endpoint `/api/export/run/{run_id}/package`.
- UI changes: updated `dashboard/index.html` to add a "Generate drafts" control, download buttons for `research_plan_draft.docx`, `thesis_draft.docx`, `slides_draft.pptx`, and a hook to list writing files via `/api/writing/run/{run_id}/files`.

### Testing

- Ran an automated Playwright script to render the updated `dashboard/index.html` and capture a screenshot showing the new draft controls, and the script completed successfully.
- Started a local HTTP server to serve `dashboard/` for the Playwright run, and the server responded during the automated capture.
- No unit test suite or CI pipeline was executed as part of this change.
- Runtime checks for `python-docx` and `python-pptx` are enforced at call-time and will raise a clear error if the libraries are missing (no automated install verification performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695200a1fcfc833093e1de92103d95a6)