### PR TITLE
Add Decision Intelligence module: Monte Carlo simulation, API, UI, and report export

### DIFF
--- a/dashboard/decision.html
+++ b/dashboard/decision.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Decision Intelligence - JARVIS</title>
+    <style>
+        :root {
+            --bg-primary: #0f0f23;
+            --bg-secondary: #1a1a2e;
+            --bg-card: #16213e;
+            --accent: #00d4ff;
+            --text-primary: #e8e8e8;
+            --text-secondary: #a0a0a0;
+            --danger: #ff4444;
+            --success: #00ff88;
+        }
+
+        body {
+            font-family: 'Segoe UI', system-ui, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            margin: 0;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: var(--accent);
+        }
+
+        .card {
+            background: var(--bg-card);
+            padding: 20px;
+            border-radius: 12px;
+            margin-bottom: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        textarea {
+            width: 100%;
+            min-height: 180px;
+            background: var(--bg-secondary);
+            color: var(--text-primary);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            border-radius: 8px;
+            padding: 10px;
+            font-family: "SFMono-Regular", Consolas, monospace;
+        }
+
+        button {
+            background: var(--accent);
+            color: var(--bg-primary);
+            border: none;
+            padding: 10px 18px;
+            border-radius: 8px;
+            cursor: pointer;
+            margin-right: 10px;
+            font-weight: 600;
+        }
+
+        .error {
+            color: var(--danger);
+            margin-top: 10px;
+        }
+
+        .success {
+            color: var(--success);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            padding: 8px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            text-align: left;
+        }
+
+        .disclaimer {
+            color: var(--text-secondary);
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+
+<body>
+<div class="container">
+    <h1>Decision Intelligence (P9)</h1>
+    <p class="disclaimer">すべての結果は仮定に依存する（推測です）。</p>
+
+    <div class="card">
+        <h2>入力</h2>
+        <p>Options と Assumptions は JSON 配列で入力してください。数値はすべて rationale を含む必要があります。</p>
+        <button id="load-template">テンプレート読み込み</button>
+        <button id="simulate">比較を実行</button>
+        <button id="download">レポートDL</button>
+        <div id="error" class="error"></div>
+    </div>
+
+    <div class="card">
+        <h3>Options (JSON)</h3>
+        <textarea id="options"></textarea>
+    </div>
+
+    <div class="card">
+        <h3>Assumptions (JSON)</h3>
+        <textarea id="assumptions"></textarea>
+    </div>
+
+    <div class="card">
+        <h2>比較結果</h2>
+        <div id="results"></div>
+    </div>
+</div>
+
+<script>
+    const optionsEl = document.getElementById('options');
+    const assumptionsEl = document.getElementById('assumptions');
+    const errorEl = document.getElementById('error');
+    const resultsEl = document.getElementById('results');
+
+    async function loadTemplate() {
+        errorEl.textContent = '';
+        const response = await fetch('/api/decision/templates');
+        const data = await response.json();
+        optionsEl.value = JSON.stringify(data.options, null, 2);
+        assumptionsEl.value = JSON.stringify(data.assumptions, null, 2);
+    }
+
+    function validatePayload(payload) {
+        const errors = [];
+        if (!payload.options || payload.options.length < 1) {
+            errors.push('Options は1つ以上必要です。');
+        }
+        if (!payload.assumptions || payload.assumptions.length < 1) {
+            errors.push('Assumptions は1つ以上必要です。');
+        }
+        payload.options?.forEach((option, index) => {
+            if (!option.time_horizon_months?.rationale) {
+                errors.push(`Option ${index + 1}: time_horizon_months の rationale が必要です。`);
+            }
+            if (!option.constraints?.weekly_hours?.rationale) {
+                errors.push(`Option ${index + 1}: weekly_hours の rationale が必要です。`);
+            }
+        });
+        payload.assumptions?.forEach((assumption, index) => {
+            if (!assumption.rationale) {
+                errors.push(`Assumption ${index + 1}: rationale が必要です。`);
+            }
+            const dist = assumption.distribution || {};
+            ['low', 'mode', 'high', 'mean', 'std', 'sigma'].forEach((key) => {
+                if (dist[key] && !dist[key].rationale) {
+                    errors.push(`Assumption ${index + 1}: ${key} の rationale が必要です。`);
+                }
+            });
+        });
+        return errors;
+    }
+
+    function renderResults(data) {
+        if (!data.results) {
+            resultsEl.innerHTML = '<p class="error">結果がありません。</p>';
+            return;
+        }
+        const rows = data.results.map(result => `
+            <tr>
+                <td>${result.label}</td>
+                <td>${result.success_probability.p10.toFixed(2)} / ${result.success_probability.p50.toFixed(2)} / ${result.success_probability.p90.toFixed(2)}</td>
+                <td>${result.expected_outputs.papers_range.p50.toFixed(2)}</td>
+                <td>${result.expected_outputs.presentations_range.p50.toFixed(2)}</td>
+            </tr>
+        `).join('');
+
+        resultsEl.innerHTML = `
+            <table>
+                <thead>
+                    <tr>
+                        <th>Option</th>
+                        <th>Success (P10/P50/P90)</th>
+                        <th>Papers P50</th>
+                        <th>Presentations P50</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${rows}
+                </tbody>
+            </table>
+            <p class="disclaimer">${data.disclaimer || '仮定に依存する（推測です）'}</p>
+        `;
+    }
+
+    async function simulate() {
+        errorEl.textContent = '';
+        resultsEl.innerHTML = '';
+        let options;
+        let assumptions;
+        try {
+            options = JSON.parse(optionsEl.value || '[]');
+            assumptions = JSON.parse(assumptionsEl.value || '[]');
+        } catch (err) {
+            errorEl.textContent = 'JSONの形式が正しくありません。';
+            return;
+        }
+
+        const payload = { options, assumptions };
+        const validationErrors = validatePayload(payload);
+        if (validationErrors.length) {
+            errorEl.textContent = validationErrors.join(' ');
+            return;
+        }
+
+        const response = await fetch('/api/decision/simulate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            const detail = await response.json();
+            errorEl.textContent = `エラー: ${JSON.stringify(detail.detail)}`;
+            return;
+        }
+
+        const data = await response.json();
+        renderResults(data);
+
+        await fetch('/api/decision/report', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ comparison: data })
+        });
+    }
+
+    async function downloadReport() {
+        window.open('/api/decision/download?format=zip', '_blank');
+    }
+
+    document.getElementById('load-template').addEventListener('click', loadTemplate);
+    document.getElementById('simulate').addEventListener('click', simulate);
+    document.getElementById('download').addEventListener('click', downloadReport);
+
+    loadTemplate();
+</script>
+</body>
+
+</html>

--- a/jarvis_core/decision/__init__.py
+++ b/jarvis_core/decision/__init__.py
@@ -1,0 +1,19 @@
+"""Decision Intelligence package."""
+
+from .model import evaluate_options
+from .schema import (
+    Assumption,
+    DecisionComparison,
+    DecisionInput,
+    DecisionResult,
+    Option,
+)
+
+__all__ = [
+    "Assumption",
+    "DecisionComparison",
+    "DecisionInput",
+    "DecisionResult",
+    "Option",
+    "evaluate_options",
+]

--- a/jarvis_core/decision/elicitation.py
+++ b/jarvis_core/decision/elicitation.py
@@ -1,0 +1,107 @@
+"""Elicitation helper for decision inputs."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import ValidationError
+
+from .schema import Assumption, DecisionInput, Option
+from .risk_factors import DEFAULT_RISK_FACTORS, default_risk_inputs
+
+
+def template_payload() -> Dict[str, object]:
+    """Return a template payload for decision input."""
+    return {
+        "options": [
+            {
+                "option_id": "A",
+                "label": "京都大 CCII 茶本研（例）",
+                "goal": "博士課程で第一著者論文1本/学位取得",
+                "theme": "がん免疫×代謝×抗体（例）",
+                "time_horizon_months": {
+                    "value": 36,
+                    "rationale": "（推測です）博士課程の想定期間",
+                },
+                "constraints": {
+                    "weekly_hours": {
+                        "value": 60,
+                        "rationale": "（推測です）研究時間の想定",
+                    },
+                    "budget_level": "medium",
+                    "equipment_access": "high",
+                    "mentor_support": "high",
+                },
+                "dependencies": {
+                    "must_learn": ["in vivo", "scRNA-seq", "bioinformatics"],
+                    "must_access": ["mouse facility", "flow core"],
+                },
+                "risk_factors": [
+                    {
+                        "name": factor.name,
+                        "score": {
+                            "value": 0.5,
+                            "rationale": "（推測です）入力未設定のため中立",
+                        },
+                        "weight": {
+                            "value": 1.0,
+                            "rationale": "（推測です）標準重み",
+                        },
+                        "rationale": factor.description,
+                    }
+                    for factor in DEFAULT_RISK_FACTORS
+                ],
+            }
+        ],
+        "assumptions": [
+            {
+                "assumption_id": "A1",
+                "name": "主要実験の立ち上げ期間",
+                "distribution": {
+                    "type": "triangular",
+                    "low": {"value": 2, "rationale": "（推測です）最低期間"},
+                    "mode": {"value": 4, "rationale": "（推測です）一般的期間"},
+                    "high": {"value": 8, "rationale": "（推測です）最長期間"},
+                    "unit": "months",
+                },
+                "rationale": "（推測です）過去類似プロジェクトの一般的目安",
+                "applies_to": "setup",
+            }
+        ],
+        "risk_factors": [
+            {
+                "name": factor.name,
+                "description": factor.description,
+            }
+            for factor in DEFAULT_RISK_FACTORS
+        ],
+        "disclaimer": "仮定に依存する（推測です）",
+    }
+
+
+def validate_payload(payload: Dict[str, object]) -> Dict[str, object]:
+    """Validate payload and return either parsed data or errors."""
+    try:
+        parsed = DecisionInput.parse_obj(payload)
+        return {
+            "valid": True,
+            "errors": [],
+            "parsed": parsed,
+        }
+    except ValidationError as exc:
+        return {
+            "valid": False,
+            "errors": exc.errors(),
+            "parsed": None,
+        }
+
+
+def normalize_risks(options: List[Option]) -> List[Option]:
+    """Ensure each option has risk factors populated."""
+    normalized = []
+    for option in options:
+        if option.risk_factors:
+            normalized.append(option)
+        else:
+            option.risk_factors = default_risk_inputs()
+            normalized.append(option)
+    return normalized

--- a/jarvis_core/decision/model.py
+++ b/jarvis_core/decision/model.py
@@ -1,0 +1,51 @@
+"""Decision probability estimation model."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .schema import (
+    Assumption,
+    DecisionComparison,
+    DecisionResult,
+    ExpectedOutputs,
+    Option,
+    ProbabilityRange,
+    RiskContribution,
+    SensitivityItem,
+)
+from .simulator import simulate_option
+from .planner import build_mvp_plan, build_kill_criteria
+
+
+def evaluate_options(options: List[Option], assumptions: List[Assumption]) -> DecisionComparison:
+    """Evaluate options and return comparison results."""
+    results: List[DecisionResult] = []
+
+    for option in options:
+        simulation = simulate_option(option, assumptions)
+        success_range = ProbabilityRange(**simulation["success_range"])
+        papers_range = ProbabilityRange(**simulation["papers_range"])
+        presentations_range = ProbabilityRange(**simulation["presentations_range"])
+
+        expected_outputs = ExpectedOutputs(
+            papers_range=papers_range,
+            presentations_range=presentations_range,
+            skill_attainment=simulation["skill_attainment"],
+        )
+
+        top_risks = [RiskContribution(**risk) for risk in simulation["contributions"]]
+        sensitivity = [SensitivityItem(**item) for item in simulation["sensitivity"]]
+
+        result = DecisionResult(
+            option_id=option.option_id,
+            label=option.label,
+            success_probability=success_range,
+            expected_outputs=expected_outputs,
+            top_risks=top_risks,
+            sensitivity=sensitivity,
+            mvp_plan=build_mvp_plan(option),
+            kill_criteria=build_kill_criteria(option),
+        )
+        results.append(result)
+
+    return DecisionComparison(results=results)

--- a/jarvis_core/decision/planner.py
+++ b/jarvis_core/decision/planner.py
@@ -1,0 +1,49 @@
+"""Generate MVP plans and kill criteria for decision options."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .schema import Option, DISCLAIMER_TEXT
+
+
+def build_mvp_plan(option: Option) -> Dict[str, List[str]]:
+    """Create a 90-day MVP plan for an option."""
+    must_learn = ", ".join(option.dependencies.must_learn) or "必須スキルの棚卸し"
+    must_access = ", ".join(option.dependencies.must_access) or "主要設備の確認"
+
+    return {
+        "disclaimer": DISCLAIMER_TEXT,
+        "first_2_weeks": [
+            "研究環境のセットアップとルール確認",
+            f"最短学習: {must_learn}",
+            f"アクセス確認: {must_access}",
+        ],
+        "day_30": [
+            "最小実験または最小データ収集の実施",
+            "成功条件を数値で定義しログ化",
+        ],
+        "day_60": [
+            "再現性チェック (再実行/別条件での再現)",
+            "解析パイプラインの最小版を確立",
+        ],
+        "day_90": [
+            "成果とリスクの再評価を実施",
+            "継続・ピボット・撤退の判断を記録",
+        ],
+    }
+
+
+def build_kill_criteria(option: Option) -> List[str]:
+    """Create measurable kill criteria for an option."""
+    criteria = [
+        "8週間以内に主要アウトプットの定量指標が1つも達成できない",
+        "主要資源(設備/データ/試薬)の利用可能時間が週10時間未満に低下",
+        "指導面談が月1回未満となり方向性レビューが途絶える",
+    ]
+
+    if option.dependencies.must_access:
+        criteria.append("必須設備の利用予約が連続4週間取得できない")
+    if option.dependencies.must_learn:
+        criteria.append("必須スキルの習得評価が60日以内に達成できない")
+
+    return criteria

--- a/jarvis_core/decision/report.py
+++ b/jarvis_core/decision/report.py
@@ -1,0 +1,76 @@
+"""Decision report generation."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from .schema import DecisionComparison, DISCLAIMER_TEXT
+
+
+def build_markdown_report(comparison: DecisionComparison) -> str:
+    """Build a markdown report from decision comparison."""
+    lines = [
+        "# Decision Intelligence Report",
+        f"- Generated: {datetime.utcnow().isoformat()}Z",
+        f"- Disclaimer: {DISCLAIMER_TEXT}",
+        "",
+    ]
+
+    for result in comparison.results:
+        lines.extend(
+            [
+                f"## Option {result.option_id}: {result.label}",
+                f"- Success Probability (P10/P50/P90): {result.success_probability.p10:.2f} / {result.success_probability.p50:.2f} / {result.success_probability.p90:.2f}",
+                f"- Papers (P10/P50/P90): {result.expected_outputs.papers_range.p10:.2f} / {result.expected_outputs.papers_range.p50:.2f} / {result.expected_outputs.papers_range.p90:.2f}",
+                f"- Presentations (P10/P50/P90): {result.expected_outputs.presentations_range.p10:.2f} / {result.expected_outputs.presentations_range.p50:.2f} / {result.expected_outputs.presentations_range.p90:.2f}",
+                "",
+                "### Top Risks",
+            ]
+        )
+        for risk in result.top_risks:
+            lines.append(f"- {risk.name}: contribution={risk.contribution:.2f}, score={risk.score:.2f}")
+
+        lines.append("\n### Sensitivity (Top 5)")
+        for item in result.sensitivity:
+            lines.append(f"- {item.name}: impact={item.impact_score:.2f}")
+
+        lines.append("\n### MVP Plan (90 days)")
+        for phase, items in result.mvp_plan.items():
+            if phase == "disclaimer":
+                continue
+            lines.append(f"- {phase}: {', '.join(items)}")
+
+        lines.append("\n### Kill Criteria")
+        for criterion in result.kill_criteria:
+            lines.append(f"- {criterion}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_html_report(markdown_report: str) -> str:
+    """Wrap markdown in a simple HTML template."""
+    escaped = markdown_report.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    escaped = escaped.replace("\n", "<br>")
+    return (
+        "<html><head><meta charset='utf-8'><title>Decision Report</title>"
+        "<style>body{font-family:Arial,sans-serif;padding:20px;background:#0f0f23;color:#e8e8e8;}"
+        "h1,h2,h3{color:#00d4ff;}br{line-height:1.6;}</style></head>"
+        f"<body>{escaped}</body></html>"
+    )
+
+
+def write_report_files(comparison: DecisionComparison, output_dir: Path) -> Dict[str, Path]:
+    """Write markdown and HTML reports to disk."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    markdown = build_markdown_report(comparison)
+    html = build_html_report(markdown)
+
+    md_path = output_dir / "decision_report.md"
+    html_path = output_dir / "decision_report.html"
+
+    md_path.write_text(markdown, encoding="utf-8")
+    html_path.write_text(html, encoding="utf-8")
+
+    return {"markdown": md_path, "html": html_path}

--- a/jarvis_core/decision/risk_factors.py
+++ b/jarvis_core/decision/risk_factors.py
@@ -1,0 +1,45 @@
+"""Risk factor definitions for decision intelligence."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .schema import RationaleValue, RiskFactorInput
+
+
+@dataclass(frozen=True)
+class RiskFactorDefinition:
+    name: str
+    description: str
+
+
+DEFAULT_RISK_FACTORS: List[RiskFactorDefinition] = [
+    RiskFactorDefinition("Technical Risk", "技術難度・実装の不確実性"),
+    RiskFactorDefinition("Data Risk", "データが得られない確率"),
+    RiskFactorDefinition("Resource Risk", "設備・試薬・計算資源の不足"),
+    RiskFactorDefinition("Competitive Risk", "競合の強さ・先行"),
+    RiskFactorDefinition("Guidance Risk", "指導・方向づけの不足"),
+    RiskFactorDefinition("Time Risk", "期限・スケジュール超過"),
+    RiskFactorDefinition("Personal Risk", "体力・集中・メンタル（自己申告）"),
+]
+
+
+def default_risk_inputs() -> List[RiskFactorInput]:
+    """Create default risk factor inputs with neutral values."""
+    default_score = RationaleValue(
+        value=0.5,
+        rationale="（推測です）入力未設定のため中立値を採用",
+    )
+    default_weight = RationaleValue(
+        value=1.0,
+        rationale="（推測です）標準重み",
+    )
+    return [
+        RiskFactorInput(
+            name=factor.name,
+            score=default_score,
+            weight=default_weight,
+            rationale=factor.description,
+        )
+        for factor in DEFAULT_RISK_FACTORS
+    ]

--- a/jarvis_core/decision/schema.py
+++ b/jarvis_core/decision/schema.py
@@ -1,0 +1,171 @@
+"""Decision Intelligence schema definitions."""
+from __future__ import annotations
+
+from typing import List, Optional, Literal
+
+from pydantic import BaseModel, Field, validator
+
+
+DISCLAIMER_TEXT = "仮定に依存する（推測です）"
+
+
+class RationaleValue(BaseModel):
+    """Numeric value that requires a rationale."""
+
+    value: float
+    rationale: str = Field(..., min_length=1)
+
+    @validator("rationale")
+    def _rationale_not_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("rationale is required for numeric values")
+        return value
+
+
+class TriangularDistribution(BaseModel):
+    """Triangular distribution parameters."""
+
+    type: Literal["triangular"]
+    low: RationaleValue
+    mode: RationaleValue
+    high: RationaleValue
+    unit: str = "months"
+
+
+class NormalDistribution(BaseModel):
+    """Normal distribution parameters."""
+
+    type: Literal["normal"]
+    mean: RationaleValue
+    std: RationaleValue
+    unit: str = "months"
+
+
+class LogNormalDistribution(BaseModel):
+    """Log-normal distribution parameters."""
+
+    type: Literal["lognormal"]
+    mean: RationaleValue
+    sigma: RationaleValue
+    unit: str = "months"
+
+
+Distribution = TriangularDistribution | NormalDistribution | LogNormalDistribution
+
+
+class Assumption(BaseModel):
+    """Assumption with distribution and rationale."""
+
+    assumption_id: str
+    name: str
+    distribution: Distribution
+    rationale: str = Field(..., min_length=1)
+    applies_to: Optional[str] = None
+
+
+class Constraints(BaseModel):
+    """Constraints for an option."""
+
+    weekly_hours: RationaleValue
+    budget_level: str
+    equipment_access: str
+    mentor_support: str
+
+
+class Dependencies(BaseModel):
+    """Dependencies for an option."""
+
+    must_learn: List[str] = []
+    must_access: List[str] = []
+
+
+class RiskFactorInput(BaseModel):
+    """Risk factor input with score and weight."""
+
+    name: str
+    score: RationaleValue
+    weight: RationaleValue
+    rationale: Optional[str] = None
+
+
+class Option(BaseModel):
+    """Decision option to evaluate."""
+
+    option_id: str
+    label: str
+    goal: str
+    theme: str
+    time_horizon_months: RationaleValue
+    constraints: Constraints
+    dependencies: Dependencies
+    risk_factors: Optional[List[RiskFactorInput]] = None
+
+
+class UserConstraints(BaseModel):
+    """User-level constraints for decision simulation."""
+
+    max_weekly_hours: Optional[RationaleValue] = None
+    preferred_budget_level: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class DecisionInput(BaseModel):
+    """Input payload for decision simulation."""
+
+    options: List[Option]
+    assumptions: List[Assumption]
+    user_constraints: Optional[UserConstraints] = None
+
+
+class ProbabilityRange(BaseModel):
+    """Probability range output."""
+
+    p10: float
+    p50: float
+    p90: float
+
+
+class ExpectedOutputs(BaseModel):
+    """Expected outputs for each option."""
+
+    papers_range: ProbabilityRange
+    presentations_range: ProbabilityRange
+    skill_attainment: dict
+
+
+class RiskContribution(BaseModel):
+    """Risk contribution output."""
+
+    name: str
+    contribution: float
+    score: float
+    weight: float
+
+
+class SensitivityItem(BaseModel):
+    """Sensitivity analysis item."""
+
+    assumption_id: str
+    name: str
+    impact_score: float
+
+
+class DecisionResult(BaseModel):
+    """Decision result for a single option."""
+
+    option_id: str
+    label: str
+    success_probability: ProbabilityRange
+    expected_outputs: ExpectedOutputs
+    top_risks: List[RiskContribution]
+    sensitivity: List[SensitivityItem]
+    mvp_plan: dict
+    kill_criteria: List[str]
+    disclaimer: str = DISCLAIMER_TEXT
+
+
+class DecisionComparison(BaseModel):
+    """Comparison response."""
+
+    results: List[DecisionResult]
+    disclaimer: str = DISCLAIMER_TEXT

--- a/jarvis_core/decision/simulator.py
+++ b/jarvis_core/decision/simulator.py
@@ -1,0 +1,166 @@
+"""Monte Carlo simulator for decision outcomes."""
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List, Tuple
+
+from .schema import Assumption, Option
+from .risk_factors import default_risk_inputs
+
+
+TASK_KEYWORDS = {
+    "setup": ["立ち上げ", "setup", "環境", "構築"],
+    "data_collection": ["データ", "収集", "in vivo", "実験"],
+    "analysis": ["解析", "analysis", "bioinformatics"],
+    "writing": ["執筆", "writing", "投稿"],
+    "revision": ["改訂", "revision", "review"],
+}
+
+
+def sample_distribution(distribution) -> float:
+    """Sample from a distribution definition."""
+    if distribution.type == "triangular":
+        return random.triangular(
+            distribution.low.value,
+            distribution.high.value,
+            distribution.mode.value,
+        )
+    if distribution.type == "normal":
+        return max(0.0, random.gauss(distribution.mean.value, distribution.std.value))
+    if distribution.type == "lognormal":
+        return random.lognormvariate(distribution.mean.value, distribution.sigma.value)
+    raise ValueError(f"Unsupported distribution type: {distribution.type}")
+
+
+def _assign_task(assumption: Assumption) -> str:
+    name = assumption.name.lower()
+    for task, keywords in TASK_KEYWORDS.items():
+        if any(keyword.lower() in name for keyword in keywords):
+            return task
+    return "general"
+
+
+def _weighted_risk(option: Option) -> Tuple[float, List[Dict[str, float]]]:
+    risk_inputs = option.risk_factors or default_risk_inputs()
+    total_weight = sum(risk.weight.value for risk in risk_inputs) or 1.0
+    weighted_score = sum(risk.score.value * risk.weight.value for risk in risk_inputs) / total_weight
+    contributions = []
+    for risk in risk_inputs:
+        contribution = (risk.score.value * risk.weight.value) / total_weight
+        contributions.append(
+            {
+                "name": risk.name,
+                "contribution": contribution,
+                "score": risk.score.value,
+                "weight": risk.weight.value,
+            }
+        )
+    return weighted_score, contributions
+
+
+def _percentile(values: List[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    rank = (percentile / 100) * (len(sorted_values) - 1)
+    low_index = math.floor(rank)
+    high_index = math.ceil(rank)
+    if low_index == high_index:
+        return sorted_values[int(rank)]
+    weight = rank - low_index
+    return sorted_values[low_index] * (1 - weight) + sorted_values[high_index] * weight
+
+
+def _correlation(xs: List[float], ys: List[int]) -> float:
+    if not xs or not ys:
+        return 0.0
+    mean_x = sum(xs) / len(xs)
+    mean_y = sum(ys) / len(ys)
+    variance_x = sum((x - mean_x) ** 2 for x in xs)
+    variance_y = sum((y - mean_y) ** 2 for y in ys)
+    if variance_x == 0 or variance_y == 0:
+        return 0.0
+    covariance = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    return covariance / math.sqrt(variance_x * variance_y)
+
+
+def simulate_option(
+    option: Option,
+    assumptions: List[Assumption],
+    iterations: int = 5000,
+) -> Dict[str, object]:
+    """Simulate an option and return Monte Carlo results."""
+    task_samples: Dict[str, List[float]] = {}
+    assumption_samples: Dict[str, List[float]] = {a.assumption_id: [] for a in assumptions}
+    successes: List[int] = []
+    success_scores: List[float] = []
+    papers: List[float] = []
+    presentations: List[float] = []
+
+    risk_score, contributions = _weighted_risk(option)
+
+    for _ in range(iterations):
+        total_time = 0.0
+        for assumption in assumptions:
+            sample = sample_distribution(assumption.distribution)
+            assumption_samples[assumption.assumption_id].append(sample)
+            total_time += sample
+            task = _assign_task(assumption)
+            task_samples.setdefault(task, []).append(sample)
+
+        risk_multiplier = 1.0 + 0.5 * risk_score
+        total_time *= risk_multiplier
+
+        horizon = option.time_horizon_months.value
+        time_gap = max(0.0, total_time - horizon)
+        time_score = max(0.0, 1 - (time_gap / max(horizon, 1.0)))
+        base_success = (0.6 * time_score) + (0.4 * (1 - risk_score))
+        base_success = max(0.0, min(1.0, base_success))
+        success_scores.append(base_success)
+        success = 1 if random.random() < base_success else 0
+        successes.append(success)
+
+        papers.append(max(0.0, success * max(1.0, total_time / 18)))
+        presentations.append(max(0.0, success * max(1.0, total_time / 12)))
+
+    success_rate = sum(successes) / len(successes) if successes else 0.0
+
+    sensitivity = []
+    for assumption in assumptions:
+        corr = abs(_correlation(assumption_samples[assumption.assumption_id], successes))
+        sensitivity.append(
+            {
+                "assumption_id": assumption.assumption_id,
+                "name": assumption.name,
+                "impact_score": corr,
+            }
+        )
+    sensitivity.sort(key=lambda item: item["impact_score"], reverse=True)
+
+    skill_attainment = {}
+    for skill in option.dependencies.must_learn:
+        attainment = max(0.0, min(1.0, 0.4 + 0.6 * success_rate - 0.3 * risk_score))
+        skill_attainment[skill] = attainment
+
+    return {
+        "success_rate": success_rate,
+        "success_range": {
+            "p10": _percentile(success_scores, 10),
+            "p50": _percentile(success_scores, 50),
+            "p90": _percentile(success_scores, 90),
+        },
+        "papers_range": {
+            "p10": _percentile(papers, 10),
+            "p50": _percentile(papers, 50),
+            "p90": _percentile(papers, 90),
+        },
+        "presentations_range": {
+            "p10": _percentile(presentations, 10),
+            "p50": _percentile(presentations, 50),
+            "p90": _percentile(presentations, 90),
+        },
+        "contributions": contributions,
+        "sensitivity": sensitivity[:5],
+        "skill_attainment": skill_attainment,
+    }

--- a/jarvis_core/export/__init__.py
+++ b/jarvis_core/export/__init__.py
@@ -1,0 +1,5 @@
+"""Export helpers."""
+
+from .package_builder import build_decision_package
+
+__all__ = ["build_decision_package"]

--- a/jarvis_core/export/package_builder.py
+++ b/jarvis_core/export/package_builder.py
@@ -1,0 +1,18 @@
+"""Package builder for decision reports."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Dict
+
+
+def build_decision_package(report_files: Dict[str, Path], output_dir: Path) -> Path:
+    """Package decision report files into a zip archive."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = output_dir / "decision_report.zip"
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        for name, path in report_files.items():
+            zip_file.write(path, arcname=path.name)
+
+    return zip_path

--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -56,6 +56,11 @@ if FASTAPI_AVAILABLE:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    from jarvis_web.routes import decision_router
+
+    app.include_router(decision_router, prefix="/api/decision", tags=["decision"])
+    app.mount("/dashboard", StaticFiles(directory="dashboard", html=True), name="dashboard")
 else:
     app = None
 

--- a/jarvis_web/routes/__init__.py
+++ b/jarvis_web/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Route modules for jarvis_web."""
+
+from .decision import router as decision_router
+
+__all__ = ["decision_router"]

--- a/jarvis_web/routes/decision.py
+++ b/jarvis_web/routes/decision.py
@@ -1,0 +1,88 @@
+"""Decision Intelligence API routes."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from jarvis_core.decision.elicitation import template_payload, validate_payload
+from jarvis_core.decision.model import evaluate_options
+from jarvis_core.decision.report import write_report_files
+from jarvis_core.export.package_builder import build_decision_package
+from jarvis_core.decision.schema import DecisionComparison
+
+router = APIRouter()
+
+REPORTS_DIR = Path("logs/decision_reports")
+LATEST_REPORT_DIR = REPORTS_DIR / "latest"
+
+
+class DecisionRequest(BaseModel):
+    """Request payload for decision simulation."""
+
+    options: list
+    assumptions: list
+    user_constraints: Optional[Dict[str, object]] = None
+
+
+class ReportRequest(BaseModel):
+    """Request payload for report generation."""
+
+    comparison: DecisionComparison
+
+
+@router.get("/templates")
+async def get_templates():
+    """Return template payload for decision inputs."""
+    return template_payload()
+
+
+@router.post("/simulate")
+async def simulate_decision(payload: Dict[str, object]):
+    """Simulate decision outcomes."""
+    validation = validate_payload(payload)
+    if not validation["valid"]:
+        raise HTTPException(status_code=400, detail={"errors": validation["errors"]})
+
+    parsed = validation["parsed"]
+    comparison = evaluate_options(parsed.options, parsed.assumptions)
+    return comparison.dict()
+
+
+@router.post("/report")
+async def generate_report(request: ReportRequest):
+    """Generate decision report files."""
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    report_dir = REPORTS_DIR / timestamp
+    files = write_report_files(request.comparison, report_dir)
+
+    LATEST_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    for path in files.values():
+        target = LATEST_REPORT_DIR / path.name
+        target.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return {
+        "report_dir": str(report_dir),
+        "files": {name: str(path) for name, path in files.items()},
+        "disclaimer": request.comparison.disclaimer,
+    }
+
+
+@router.get("/download")
+async def download_report(format: str = "zip"):
+    """Download the latest decision report package."""
+    if format != "zip":
+        raise HTTPException(status_code=400, detail="Only zip format is supported")
+
+    md_path = LATEST_REPORT_DIR / "decision_report.md"
+    html_path = LATEST_REPORT_DIR / "decision_report.html"
+
+    if not md_path.exists() or not html_path.exists():
+        raise HTTPException(status_code=404, detail="No report available")
+
+    zip_path = build_decision_package({"markdown": md_path, "html": html_path}, LATEST_REPORT_DIR)
+    return FileResponse(zip_path, filename=zip_path.name, media_type="application/zip")


### PR DESCRIPTION
### Motivation
- Implement a Decision Intelligence P9 feature to let users compare multiple PhD/ research options under explicit assumptions and receive probability ranges and actionable plans. 
- Require rationale for all numeric inputs and keep all outputs explicitly labeled as assumption-driven (disclaimer). 
- Provide explainability via risk factor contributions and sensitivity analysis to show why results change. 
- Deliver a minimal end-to-end flow: input → simulate (P10/P50/P90) → generate MVP plan / kill criteria → report export.

### Description
- Added a decision core package with schema, elicitation, Monte Carlo simulator, model wrapper, risk factor defaults, planner, and report generator under `jarvis_core/decision` (files include `schema.py`, `elicitation.py`, `simulator.py`, `model.py`, `risk_factors.py`, `planner.py`, `report.py`, and `__init__.py`).
- Implemented a Monte Carlo simulator (`simulate_option`) with default `iterations=5000` producing `success_range` (P10/P50/P90), expected outputs (papers/presentations), `top_risks`, and `sensitivity` items, and adjusted simulator to compute percentile ranges from continuous success scores. 
- Exposed HTTP endpoints in `jarvis_web/routes/decision.py` (`/api/decision/templates`, `/api/decision/simulate`, `/api/decision/report`, `/api/decision/download`) and mounted the router in `jarvis_web/app.py` under `/api/decision` while serving the dashboard static route. 
- Added a client UI `dashboard/decision.html` with template loading, client-side validation enforcing `rationale` requirements, simulate/report flows, and report packaging via new export helper `jarvis_core/export/package_builder.py`.

### Testing
- Started a simple static server with `python -m http.server 8000` to serve the dashboard page which ran (server launched). 
- Attempted an automated UI capture with Playwright which failed due to Chromium crashing (`TargetClosedError` / SIGSEGV), so browser-based end-to-end verification did not complete. 
- No automated unit test suite was run as part of this rollout (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952029172108330ae5ed2c33b2957c7)