### PR TITLE
P10: Add finance/time optimization scaffolding and finance API/dashboard

### DIFF
--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>P10 資金×時間最適化</title>
+  <style>
+    body {
+      font-family: "Segoe UI", sans-serif;
+      margin: 0;
+      padding: 24px;
+      background: #f7f8fb;
+      color: #1e1f23;
+    }
+    header {
+      margin-bottom: 20px;
+    }
+    h1 {
+      margin: 0 0 8px 0;
+    }
+    .note {
+      color: #6d6f76;
+      font-size: 0.9rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .card {
+      background: #ffffff;
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 8px 20px rgba(15, 18, 30, 0.08);
+    }
+    .badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      margin-right: 6px;
+    }
+    .badge.warn {
+      background: #fff3cd;
+      color: #8b6c00;
+    }
+    .badge.danger {
+      background: #fde2e2;
+      color: #b42318;
+    }
+    .badge.ok {
+      background: #e7f7ef;
+      color: #107154;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+    th, td {
+      padding: 10px;
+      border-bottom: 1px solid #e6e8ec;
+      text-align: left;
+    }
+    th {
+      background: #f2f4f8;
+    }
+    .scenario {
+      margin-top: 12px;
+    }
+    .scenario h3 {
+      margin: 8px 0;
+    }
+    .summary {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .summary span {
+      background: #eef2ff;
+      padding: 6px 10px;
+      border-radius: 8px;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>P10 資金×時間最適化ダッシュボード</h1>
+    <div class="note">すべての数値・提案は仮定に基づく推測です。</div>
+  </header>
+
+  <section class="grid">
+    <div class="card">
+      <h2>警告バッジ</h2>
+      <div>
+        <span class="badge danger">赤字リスク</span>
+        <span class="badge warn">過労リスク</span>
+        <span class="badge warn">研究遅延</span>
+        <span class="badge ok">成立可能</span>
+      </div>
+      <p class="note">シナリオごとに自動検知（推測です）。</p>
+    </div>
+    <div class="card">
+      <h2>週次可処分時間</h2>
+      <div class="summary">
+        <span>研究 45h</span>
+        <span>RA/TA 10h</span>
+        <span>休養 15h</span>
+      </div>
+      <p class="note">P9の計画と照合（推測です）。</p>
+    </div>
+    <div class="card">
+      <h2>月次キャッシュフロー</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>月</th>
+            <th>収入</th>
+            <th>支出</th>
+            <th>残高</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>2025-04</td>
+            <td>¥250,000</td>
+            <td>¥155,000</td>
+            <td>¥395,000</td>
+          </tr>
+          <tr>
+            <td>2025-05</td>
+            <td>¥230,000</td>
+            <td>¥155,000</td>
+            <td>¥470,000</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note">期待値と下振れを併記（推測です）。</p>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>シナリオ比較</h2>
+    <div class="scenario">
+      <h3>S1: DC1採択（RAなし）</h3>
+      <div class="summary">
+        <span>status: feasible</span>
+        <span>最低残高: ¥320,000</span>
+        <span>研究達成率: 95%</span>
+      </div>
+    </div>
+    <div class="scenario">
+      <h3>S2: DC1不採択＋RA/TA</h3>
+      <div class="summary">
+        <span>status: risky</span>
+        <span>最低残高: ¥120,000</span>
+        <span>研究達成率: 85%</span>
+      </div>
+    </div>
+    <div class="scenario">
+      <h3>S4: 最悪ケース</h3>
+      <div class="summary">
+        <span>status: infeasible</span>
+        <span>破綻月: 2026-02</span>
+        <span>過労リスク: 高</span>
+      </div>
+    </div>
+    <p class="note">最適/準最適解の提示は説明可能性を優先（推測です）。</p>
+  </section>
+</body>
+</html>

--- a/jarvis_core/decision/__init__.py
+++ b/jarvis_core/decision/__init__.py
@@ -1,0 +1,1 @@
+"""Decision support modules for planning."""

--- a/jarvis_core/decision/planner.py
+++ b/jarvis_core/decision/planner.py
@@ -1,0 +1,43 @@
+"""Decision planner connecting research plan to finance/time constraints."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from jarvis_core.time.schema import WeekAllocation, DEFAULT_NOTE
+
+
+@dataclass
+class PlanAlignment:
+    """Alignment result between plan hours and available time."""
+
+    planned_research_hours: int
+    available_research_target: int
+    shortfall: int
+    aligned: bool
+    note: str = DEFAULT_NOTE
+
+
+def evaluate_plan_alignment(
+    planned_research_hours: int,
+    allocation: WeekAllocation,
+) -> PlanAlignment:
+    """Check if planned research hours fit within time allocation."""
+    available_target = allocation.variable.research.target
+    shortfall = max(0, planned_research_hours - available_target)
+    aligned = shortfall == 0
+    return PlanAlignment(
+        planned_research_hours=planned_research_hours,
+        available_research_target=available_target,
+        shortfall=shortfall,
+        aligned=aligned,
+    )
+
+
+def estimate_delay_cost(monthly_rent: int, delay_months: int) -> Dict[str, object]:
+    """Estimate cost impact of research delay."""
+    return {
+        "delay_months": delay_months,
+        "cost": monthly_rent * delay_months,
+        "note": DEFAULT_NOTE,
+    }

--- a/jarvis_core/export/__init__.py
+++ b/jarvis_core/export/__init__.py
@@ -1,0 +1,1 @@
+"""Export utilities for reports and packages."""

--- a/jarvis_core/export/package_builder.py
+++ b/jarvis_core/export/package_builder.py
@@ -1,0 +1,36 @@
+"""Package builder for finance/optimization reports."""
+from __future__ import annotations
+
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+from jarvis_core.optimization.report import build_report
+from jarvis_core.optimization.solver import OptimizationResult
+
+
+def build_finance_package(results: Iterable[OptimizationResult], format: str = "md") -> Path:
+    """Build a zip package containing the finance report."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        report_text = build_report(results, format=format)
+        report_name = f"finance_report.{format}"
+        report_path = temp_path / report_name
+        report_path.write_text(report_text, encoding="utf-8")
+
+        json_path = temp_path / "finance_report.json"
+        json_path.write_text(
+            json.dumps([result.__dict__ for result in results], ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        zip_path = temp_path / "finance_report.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.write(report_path, report_name)
+            zip_file.write(json_path, "finance_report.json")
+
+        output_path = Path(tempfile.gettempdir()) / "finance_report.zip"
+        output_path.write_bytes(zip_path.read_bytes())
+        return output_path

--- a/jarvis_core/finance/__init__.py
+++ b/jarvis_core/finance/__init__.py
@@ -1,0 +1,1 @@
+"""Finance utilities for resource optimization."""

--- a/jarvis_core/finance/scenarios.py
+++ b/jarvis_core/finance/scenarios.py
@@ -1,0 +1,114 @@
+"""Scenario definitions for finance planning."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List
+
+from .schema import MonthlyCashFlow, IncomeItem, ExpenseItem, DEFAULT_NOTE
+
+
+@dataclass
+class FinanceScenario:
+    """Finance scenario for simulation and optimization."""
+
+    scenario_id: str
+    name: str
+    description: str
+    cashflows: List[MonthlyCashFlow]
+
+
+def _month_sequence(start_month: str, months: int) -> List[str]:
+    start = datetime.strptime(start_month, "%Y-%m")
+    result = []
+    year = start.year
+    month = start.month
+    for _ in range(months):
+        result.append(f"{year:04d}-{month:02d}")
+        month += 1
+        if month > 12:
+            year += 1
+            month = 1
+    return result
+
+
+def _base_expenses() -> List[ExpenseItem]:
+    return [
+        ExpenseItem(type="rent", amount=70000, note=DEFAULT_NOTE),
+        ExpenseItem(type="food", amount=40000, note=DEFAULT_NOTE),
+        ExpenseItem(type="utilities", amount=15000, note=DEFAULT_NOTE),
+        ExpenseItem(type="insurance", amount=10000, note=DEFAULT_NOTE),
+        ExpenseItem(type="misc", amount=20000, note=DEFAULT_NOTE),
+    ]
+
+
+def _make_cashflows(start_month: str, months: int, income_template: List[IncomeItem]) -> List[MonthlyCashFlow]:
+    cashflows = []
+    for idx, month in enumerate(_month_sequence(start_month, months)):
+        cashflows.append(
+            MonthlyCashFlow(
+                month=month,
+                income=[item.with_note() for item in income_template],
+                expenses=[item.with_note() for item in _base_expenses()],
+                savings_start=300000 if idx == 0 else 0,
+            ).normalized()
+        )
+    return cashflows
+
+
+def default_scenarios(start_month: str = "2025-04", months: int = 36) -> Dict[str, FinanceScenario]:
+    """Return default finance scenarios."""
+    scenarios = {
+        "S1": FinanceScenario(
+            scenario_id="S1",
+            name="DC1採択（RAなし）",
+            description="DC1が採択されたケース。（推測です）",
+            cashflows=_make_cashflows(
+                start_month,
+                months,
+                [
+                    IncomeItem(type="DC1", amount=200000, prob=0.9, note=DEFAULT_NOTE),
+                ],
+            ),
+        ),
+        "S2": FinanceScenario(
+            scenario_id="S2",
+            name="DC1不採択＋RA/TA",
+            description="RA/TAで補填するケース。（推測です）",
+            cashflows=_make_cashflows(
+                start_month,
+                months,
+                [
+                    IncomeItem(type="DC1", amount=200000, prob=0.2, note=DEFAULT_NOTE),
+                    IncomeItem(type="RA", amount=50000, hours=10, note=DEFAULT_NOTE),
+                    IncomeItem(type="TA", amount=30000, hours=5, note=DEFAULT_NOTE),
+                ],
+            ),
+        ),
+        "S3": FinanceScenario(
+            scenario_id="S3",
+            name="奨学金＋バイト併用",
+            description="奨学金とバイト併用。（推測です）",
+            cashflows=_make_cashflows(
+                start_month,
+                months,
+                [
+                    IncomeItem(type="Scholarship", amount=120000, prob=0.6, note=DEFAULT_NOTE),
+                    IncomeItem(type="Part-time", amount=60000, hours=8, note=DEFAULT_NOTE),
+                ],
+            ),
+        ),
+        "S4": FinanceScenario(
+            scenario_id="S4",
+            name="最悪ケース（収入不安定）",
+            description="奨学金なし・収入不安定。（推測です）",
+            cashflows=_make_cashflows(
+                start_month,
+                months,
+                [
+                    IncomeItem(type="Temporary", amount=80000, prob=0.4, note=DEFAULT_NOTE),
+                ],
+            ),
+        ),
+    }
+    return scenarios

--- a/jarvis_core/finance/schema.py
+++ b/jarvis_core/finance/schema.py
@@ -1,0 +1,78 @@
+"""Finance schema definitions for monthly cashflow modeling."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+DEFAULT_NOTE = "（推測です）"
+
+
+@dataclass
+class IncomeItem:
+    """Monthly income item."""
+
+    type: str
+    amount: int
+    note: str = DEFAULT_NOTE
+    prob: Optional[float] = None
+    hours: Optional[int] = None
+
+    def expected_amount(self) -> float:
+        """Return expected value based on probability."""
+        if self.prob is None:
+            return float(self.amount)
+        return float(self.amount) * self.prob
+
+    def downside_amount(self) -> float:
+        """Return downside value assuming uncertain income can be lost."""
+        if self.prob is None:
+            return float(self.amount)
+        if self.prob >= 1:
+            return float(self.amount)
+        return 0.0
+
+    def with_note(self) -> "IncomeItem":
+        """Ensure note is populated."""
+        if not self.note:
+            self.note = DEFAULT_NOTE
+        return self
+
+
+@dataclass
+class ExpenseItem:
+    """Monthly expense item."""
+
+    type: str
+    amount: int
+    note: str = DEFAULT_NOTE
+
+    def with_note(self) -> "ExpenseItem":
+        """Ensure note is populated."""
+        if not self.note:
+            self.note = DEFAULT_NOTE
+        return self
+
+
+@dataclass
+class MonthlyCashFlow:
+    """Monthly cash flow snapshot."""
+
+    month: str
+    income: List[IncomeItem] = field(default_factory=list)
+    expenses: List[ExpenseItem] = field(default_factory=list)
+    savings_start: int = 0
+
+    def expected_income(self) -> float:
+        return sum(item.expected_amount() for item in self.income)
+
+    def downside_income(self) -> float:
+        return sum(item.downside_amount() for item in self.income)
+
+    def total_expenses(self) -> float:
+        return sum(item.amount for item in self.expenses)
+
+    def normalized(self) -> "MonthlyCashFlow":
+        """Ensure all notes are populated."""
+        self.income = [item.with_note() for item in self.income]
+        self.expenses = [item.with_note() for item in self.expenses]
+        return self

--- a/jarvis_core/optimization/__init__.py
+++ b/jarvis_core/optimization/__init__.py
@@ -1,0 +1,1 @@
+"""Optimization utilities for finance/time planning."""

--- a/jarvis_core/optimization/constraints.py
+++ b/jarvis_core/optimization/constraints.py
@@ -1,0 +1,53 @@
+"""Constraint evaluation for finance/time optimization."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from jarvis_core.finance.schema import MonthlyCashFlow
+from jarvis_core.time.schema import WeekAllocation
+
+
+def evaluate_constraints(
+    cashflows: List[MonthlyCashFlow],
+    allocation: WeekAllocation,
+    planned_research_hours: int,
+) -> Dict[str, object]:
+    """Evaluate hard/soft constraints and return flags."""
+    balance = cashflows[0].savings_start if cashflows else 0
+    deficit_months = []
+    for flow in cashflows:
+        balance += flow.downside_income() - flow.total_expenses()
+        if balance < 0:
+            deficit_months.append(flow.month)
+
+    sleep_shortfall = allocation.sleep_hours_per_day() < 6
+    overwork = allocation.work_hours_max() > 80
+    research_shortfall = allocation.variable.research.target < planned_research_hours
+    focus_overflow = allocation.work_hours_target() > allocation.available_hours()
+
+    hard_violations = []
+    if deficit_months:
+        hard_violations.append("月末残高が赤字")
+    if overwork:
+        hard_violations.append("週労働時間が80h超過")
+    if sleep_shortfall:
+        hard_violations.append("睡眠が6h/日未満")
+
+    soft_penalties = []
+    if research_shortfall:
+        soft_penalties.append("研究時間がtarget未満")
+    if focus_overflow:
+        soft_penalties.append("研究+RA/TA+バイトが可処分時間超過")
+    if allocation.variable.rest.target < allocation.variable.rest.min:
+        soft_penalties.append("余暇がmin未満")
+    if cashflows and cashflows[0].savings_start < 0:
+        soft_penalties.append("貯蓄が初期値を下回る")
+
+    return {
+        "deficit_months": deficit_months,
+        "hard_violations": hard_violations,
+        "soft_penalties": soft_penalties,
+        "research_shortfall": research_shortfall,
+        "overwork": overwork,
+        "sleep_shortfall": sleep_shortfall,
+    }

--- a/jarvis_core/optimization/report.py
+++ b/jarvis_core/optimization/report.py
@@ -1,0 +1,47 @@
+"""Report builder for finance/time optimization."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from jarvis_core.optimization.solver import OptimizationResult
+
+
+def build_report(results: Iterable[OptimizationResult], format: str = "md") -> str:
+    """Build a report in markdown or HTML."""
+    lines = []
+    if format == "html":
+        lines.append("<h1>資金・時間最適化レポート</h1>")
+        lines.append("<p>すべての数値は仮定に基づく推測です。</p>")
+        for result in results:
+            lines.append(
+                "<h2>シナリオ {}</h2>".format(result.scenario)
+            )
+            lines.append("<ul>")
+            lines.append(f"<li>status: {result.status}</li>")
+            lines.append(f"<li>expected_balance_end: {result.expected_balance_end}</li>")
+            lines.append(f"<li>bankruptcy_risk: {result.bankruptcy_risk}</li>")
+            lines.append(f"<li>research_hours_avg: {result.research_hours_avg}</li>")
+            lines.append(f"<li>overwork_risk: {result.overwork_risk}</li>")
+            lines.append(f"<li>recommendation: {result.recommendation}</li>")
+            if "minimum_balance" in result.details:
+                lines.append(f"<li>minimum_balance: {result.details['minimum_balance']}</li>")
+            if "deficit_probability" in result.details:
+                lines.append(f"<li>deficit_probability: {result.details['deficit_probability']}</li>")
+            lines.append("</ul>")
+        return "\n".join(lines)
+
+    lines.append("# 資金・時間最適化レポート")
+    lines.append("すべての数値は仮定に基づく推測です。")
+    for result in results:
+        lines.append(f"## シナリオ {result.scenario}")
+        lines.append(f"- status: {result.status}")
+        lines.append(f"- expected_balance_end: {result.expected_balance_end}")
+        lines.append(f"- bankruptcy_risk: {result.bankruptcy_risk}")
+        lines.append(f"- research_hours_avg: {result.research_hours_avg}")
+        lines.append(f"- overwork_risk: {result.overwork_risk}")
+        lines.append(f"- recommendation: {result.recommendation}")
+        if "minimum_balance" in result.details:
+            lines.append(f"- minimum_balance: {result.details['minimum_balance']}")
+        if "deficit_probability" in result.details:
+            lines.append(f"- deficit_probability: {result.details['deficit_probability']}")
+    return "\n".join(lines)

--- a/jarvis_core/optimization/solver.py
+++ b/jarvis_core/optimization/solver.py
@@ -1,0 +1,124 @@
+"""Heuristic solver for finance/time optimization."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from jarvis_core.finance.scenarios import FinanceScenario
+from jarvis_core.optimization.constraints import evaluate_constraints
+from jarvis_core.time.schema import WeekAllocation
+
+
+@dataclass
+class OptimizationResult:
+    scenario: str
+    status: str
+    expected_balance_end: int
+    bankruptcy_risk: float
+    research_hours_avg: float
+    overwork_risk: float
+    recommendation: str
+    details: Dict[str, object]
+
+
+def _simulate_balance(cashflows, use_expected: bool) -> int:
+    balance = cashflows[0].savings_start if cashflows else 0
+    for flow in cashflows:
+        income = flow.expected_income() if use_expected else flow.downside_income()
+        balance += income - flow.total_expenses()
+    return int(balance)
+
+
+def _bankruptcy_risk(cashflows) -> float:
+    balance = cashflows[0].savings_start if cashflows else 0
+    risk_months = 0
+    for flow in cashflows:
+        balance += flow.downside_income() - flow.total_expenses()
+        if balance < 0:
+            risk_months += 1
+    if not cashflows:
+        return 0.0
+    return round(risk_months / len(cashflows), 2)
+
+
+def _min_balance(cashflows, use_expected: bool) -> int:
+    balance = cashflows[0].savings_start if cashflows else 0
+    minimum = balance
+    for flow in cashflows:
+        income = flow.expected_income() if use_expected else flow.downside_income()
+        balance += income - flow.total_expenses()
+        minimum = min(minimum, balance)
+    return int(minimum)
+
+
+def _deficit_probability(cashflows) -> float:
+    if not cashflows:
+        return 0.0
+    balance = cashflows[0].savings_start
+    deficit_months = 0
+    for flow in cashflows:
+        balance += flow.downside_income() - flow.total_expenses()
+        if balance < 0:
+            deficit_months += 1
+    return round(deficit_months / len(cashflows), 2)
+
+
+def optimize_scenarios(
+    scenarios: Dict[str, FinanceScenario],
+    allocation: WeekAllocation,
+    planned_research_hours: int,
+) -> List[OptimizationResult]:
+    """Return optimization results per scenario."""
+    results: List[OptimizationResult] = []
+    for scenario_id, scenario in scenarios.items():
+        constraints = evaluate_constraints(
+            scenario.cashflows,
+            allocation,
+            planned_research_hours,
+        )
+        expected_end = _simulate_balance(scenario.cashflows, use_expected=True)
+        bankruptcy_risk = _bankruptcy_risk(scenario.cashflows)
+        deficit_probability = _deficit_probability(scenario.cashflows)
+        min_balance = _min_balance(scenario.cashflows, use_expected=True)
+        overwork_risk = 1.0 if constraints["overwork"] else 0.18
+        research_avg = allocation.variable.research.target
+        attainment_rate = round(
+            min(1.0, research_avg / planned_research_hours) if planned_research_hours else 1.0,
+            2,
+        )
+
+        if constraints["hard_violations"]:
+            status = "infeasible"
+        elif constraints["soft_penalties"] or bankruptcy_risk >= 0.2:
+            status = "risky"
+        else:
+            status = "feasible"
+
+        recommendation_parts = []
+        if constraints["overwork"]:
+            recommendation_parts.append("RA/TA時間を週8hに抑えると過労リスクが下がる（推測です）")
+        if constraints["research_shortfall"]:
+            recommendation_parts.append("研究時間のtargetを増やすと計画遅延が緩和される（推測です）")
+        if not recommendation_parts:
+            recommendation_parts.append("現状の配分を維持しつつ定期的に見直す（推測です）")
+
+        results.append(
+            OptimizationResult(
+                scenario=scenario_id,
+                status=status,
+                expected_balance_end=expected_end,
+                bankruptcy_risk=bankruptcy_risk,
+                research_hours_avg=research_avg,
+                overwork_risk=overwork_risk,
+                recommendation=" / ".join(recommendation_parts),
+                details={
+                    "constraints": constraints,
+                    "expected_balance_end": expected_end,
+                    "minimum_balance": min_balance,
+                    "deficit_probability": deficit_probability,
+                    "research_attainment_rate": attainment_rate,
+                    "note": "（推測です）",
+                },
+            )
+        )
+    return results

--- a/jarvis_core/time/__init__.py
+++ b/jarvis_core/time/__init__.py
@@ -1,0 +1,1 @@
+"""Time allocation utilities for resource optimization."""

--- a/jarvis_core/time/calendar_builder.py
+++ b/jarvis_core/time/calendar_builder.py
@@ -1,0 +1,38 @@
+"""Calendar builder for weekly/monthly summaries."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Dict
+
+from .schema import WeekAllocation, DEFAULT_NOTE
+
+
+def build_weekly_calendar(start_month: str, months: int, allocation: WeekAllocation) -> List[Dict[str, object]]:
+    """Build a weekly calendar summary for each month.
+
+    Uses a simplified 4-week assumption per month (推測です).
+    """
+    start = datetime.strptime(start_month, "%Y-%m")
+    current_year = start.year
+    current_month = start.month
+    calendar: List[Dict[str, object]] = []
+    for _ in range(months):
+        month_label = f"{current_year:04d}-{current_month:02d}"
+        for week_index in range(1, 5):
+            calendar.append(
+                {
+                    "month": month_label,
+                    "week": week_index,
+                    "hours": {
+                        "fixed": allocation.fixed_total(),
+                        "variable_target": allocation.variable_target_total(),
+                        "available": allocation.available_hours(),
+                    },
+                    "note": DEFAULT_NOTE,
+                }
+            )
+        current_month += 1
+        if current_month > 12:
+            current_month = 1
+            current_year += 1
+    return calendar

--- a/jarvis_core/time/schema.py
+++ b/jarvis_core/time/schema.py
@@ -1,0 +1,97 @@
+"""Time allocation schema for weekly planning."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+DEFAULT_NOTE = "（推測です）"
+
+
+@dataclass
+class FixedHours:
+    sleep: int
+    meals: int
+    commute: int
+
+    def total(self) -> int:
+        return self.sleep + self.meals + self.commute
+
+
+@dataclass
+class VariableRange:
+    min: int
+    target: int
+    max: int
+    note: str = DEFAULT_NOTE
+
+
+@dataclass
+class VariableHours:
+    research: VariableRange
+    coursework: VariableRange
+    ra_ta: VariableRange
+    part_time: VariableRange
+    rest: VariableRange
+
+    def as_dict(self) -> Dict[str, VariableRange]:
+        return {
+            "research": self.research,
+            "coursework": self.coursework,
+            "ra_ta": self.ra_ta,
+            "part_time": self.part_time,
+            "rest": self.rest,
+        }
+
+
+@dataclass
+class WeekAllocation:
+    week_hours: int
+    fixed: FixedHours
+    variable: VariableHours
+
+    def fixed_total(self) -> int:
+        return self.fixed.total()
+
+    def variable_target_total(self) -> int:
+        return sum(item.target for item in self.variable.as_dict().values())
+
+    def variable_max_total(self) -> int:
+        return sum(item.max for item in self.variable.as_dict().values())
+
+    def available_hours(self) -> int:
+        return self.week_hours - self.fixed_total()
+
+    def work_hours_target(self) -> int:
+        return (
+            self.variable.research.target
+            + self.variable.ra_ta.target
+            + self.variable.part_time.target
+        )
+
+    def work_hours_max(self) -> int:
+        return (
+            self.variable.research.max
+            + self.variable.ra_ta.max
+            + self.variable.part_time.max
+        )
+
+    def overwork_flag(self) -> bool:
+        """Flag overwork when research/ra/part-time exceed available hours."""
+        return self.work_hours_target() > self.available_hours()
+
+    def sleep_hours_per_day(self) -> float:
+        return self.fixed.sleep / 7
+
+
+def default_week_allocation() -> WeekAllocation:
+    return WeekAllocation(
+        week_hours=168,
+        fixed=FixedHours(sleep=56, meals=14, commute=10),
+        variable=VariableHours(
+            research=VariableRange(min=30, target=45, max=60),
+            coursework=VariableRange(min=0, target=5, max=10),
+            ra_ta=VariableRange(min=0, target=10, max=20),
+            part_time=VariableRange(min=0, target=0, max=10),
+            rest=VariableRange(min=10, target=15, max=20),
+        ),
+    )

--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -47,6 +47,8 @@ if FASTAPI_AVAILABLE:
         description="API for paper survey and knowledge synthesis",
         version="4.3.0",
     )
+
+    from jarvis_web.routes.finance import router as finance_router
     
     # Add CORS middleware to allow cross-origin requests (for GitHub Pages dashboard)
     app.add_middleware(
@@ -56,6 +58,9 @@ if FASTAPI_AVAILABLE:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    if finance_router is not None:
+        app.include_router(finance_router)
 else:
     app = None
 

--- a/jarvis_web/routes/__init__.py
+++ b/jarvis_web/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API routes for Jarvis Web."""

--- a/jarvis_web/routes/finance.py
+++ b/jarvis_web/routes/finance.py
@@ -1,0 +1,99 @@
+"""Finance routes for P10 optimization."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+try:
+    from fastapi import APIRouter, HTTPException
+    from fastapi.responses import FileResponse, PlainTextResponse
+    from pydantic import BaseModel
+
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+    APIRouter = None
+    BaseModel = object
+
+from jarvis_core.finance.scenarios import default_scenarios
+from jarvis_core.optimization.solver import optimize_scenarios
+from jarvis_core.optimization.report import build_report
+from jarvis_core.time.schema import default_week_allocation
+from jarvis_core.export.package_builder import build_finance_package
+
+
+class SimulateRequest(BaseModel):
+    start_month: str = "2025-04"
+    months: int = 36
+    planned_research_hours: int = 45
+
+
+class OptimizeResponse(BaseModel):
+    scenario: str
+    status: str
+    expected_balance_end: int
+    bankruptcy_risk: float
+    research_hours_avg: float
+    overwork_risk: float
+    recommendation: str
+    note: str = "（推測です）"
+
+
+router = APIRouter() if FASTAPI_AVAILABLE else None
+
+
+if FASTAPI_AVAILABLE:
+
+    @router.post("/api/finance/simulate", response_model=List[OptimizeResponse])
+    async def simulate_finance(payload: SimulateRequest) -> List[OptimizeResponse]:
+        scenarios = default_scenarios(payload.start_month, payload.months)
+        allocation = default_week_allocation()
+        results = optimize_scenarios(scenarios, allocation, payload.planned_research_hours)
+        return [
+            OptimizeResponse(
+                scenario=result.scenario,
+                status=result.status,
+                expected_balance_end=result.expected_balance_end,
+                bankruptcy_risk=result.bankruptcy_risk,
+                research_hours_avg=result.research_hours_avg,
+                overwork_risk=result.overwork_risk,
+                recommendation=result.recommendation,
+            )
+            for result in results
+        ]
+
+    @router.post("/api/finance/optimize", response_model=OptimizeResponse)
+    async def optimize_finance(payload: SimulateRequest) -> OptimizeResponse:
+        scenarios = default_scenarios(payload.start_month, payload.months)
+        allocation = default_week_allocation()
+        results = optimize_scenarios(scenarios, allocation, payload.planned_research_hours)
+        if not results:
+            raise HTTPException(status_code=404, detail="No scenarios available")
+        best = sorted(results, key=lambda r: (r.status != "feasible", r.bankruptcy_risk))[0]
+        return OptimizeResponse(
+            scenario=best.scenario,
+            status=best.status,
+            expected_balance_end=best.expected_balance_end,
+            bankruptcy_risk=best.bankruptcy_risk,
+            research_hours_avg=best.research_hours_avg,
+            overwork_risk=best.overwork_risk,
+            recommendation=best.recommendation,
+        )
+
+    @router.get("/api/finance/report")
+    async def finance_report(format: Optional[str] = "md"):
+        scenarios = default_scenarios()
+        allocation = default_week_allocation()
+        results = optimize_scenarios(scenarios, allocation, allocation.variable.research.target)
+        fmt = "html" if format == "html" else "md"
+        report_text = build_report(results, format=fmt)
+        media_type = "text/html" if fmt == "html" else "text/markdown"
+        return PlainTextResponse(report_text, media_type=media_type)
+
+    @router.get("/api/finance/download")
+    async def finance_download(format: Optional[str] = "md"):
+        scenarios = default_scenarios()
+        allocation = default_week_allocation()
+        results = optimize_scenarios(scenarios, allocation, allocation.variable.research.target)
+        fmt = "html" if format == "html" else "md"
+        zip_path = build_finance_package(results, format=fmt)
+        return FileResponse(zip_path, filename="finance_report.zip")


### PR DESCRIPTION
### Motivation
- Implement the P10 resource-optimization capability to integrate monthly cashflow and weekly time allocation under constrained research progress assumptions.
- Enable comparison of multiple funding/time scenarios (e.g. DC1, RA/TA, scholarship, worst-case) and automatic detection of bankruptcy, overwork, and plan delay risks.
- Provide explainable, assumption-annotated optimization output and actionable recommendations while keeping assertions as conjectures.
- Expose the functionality via HTTP endpoints and a simple dashboard for visual inspection and report export.

### Description
- Added finance/time schemas and scenario defaults in `jarvis_core/finance/schema.py`, `jarvis_core/finance/scenarios.py`, `jarvis_core/time/schema.py`, and `jarvis_core/time/calendar_builder.py`, plus a decision alignment helper in `jarvis_core/decision/planner.py`.
- Implemented constraint evaluation, a heuristic solver and richer outputs in `jarvis_core/optimization/constraints.py`, `jarvis_core/optimization/solver.py`, and `jarvis_core/optimization/report.py` that include `minimum_balance`, `deficit_probability`, and `research_attainment_rate` details.
- Added packaging/export helper `jarvis_core/export/package_builder.py` to produce a downloadable zip and wired a FastAPI route module at `jarvis_web/routes/finance.py` with endpoints `POST /api/finance/simulate`, `POST /api/finance/optimize`, `GET /api/finance/report`, and `GET /api/finance/download` and mounted it in `jarvis_web/app.py`.
- Included a static dashboard view at `dashboard/finance.html` to visualize scenario badges, weekly availability, and a sample monthly cashflow table.

### Testing
- Rendered `dashboard/finance.html` by serving the repository with `python -m http.server` and captured a screenshot using Playwright to `artifacts/finance-dashboard.png`, which completed successfully.
- No automated unit/CI tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695202e94fd083308ea0eab200cd29ea)