### PR TITLE
dashboard: add API adapter, capability detection, fallbacks and resilient UI

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -1,0 +1,347 @@
+(function (global) {
+    const storage = global.JarvisStorage;
+    const errors = global.JarvisErrors;
+    const parsers = global.JarvisParsers;
+    const fallbacks = global.JarvisFallbacks;
+    const capabilities = global.JarvisCapabilities;
+
+    const DEFAULT_TIMEOUT_MS = 15000;
+
+    function buildUrl(path) {
+        if (!path) return '';
+        if (/^https?:\/\//i.test(path)) return path;
+        const base = storage.getApiBase();
+        if (!base) return path;
+        return `${base.replace(/\/$/, '')}${path}`;
+    }
+
+    async function apiFetch(path, opts = {}) {
+        const controller = new AbortController();
+        const timeout = opts.timeoutMs || DEFAULT_TIMEOUT_MS;
+        const token = storage.getToken();
+        const headers = new Headers(opts.headers || {});
+        if (token) {
+            headers.set('Authorization', `Bearer ${token}`);
+        }
+        const url = buildUrl(path);
+        const timer = setTimeout(() => controller.abort(), timeout);
+        try {
+            const response = await fetch(url, {
+                ...opts,
+                headers,
+                signal: controller.signal
+            });
+            if (!response.ok) {
+                throw errors.normalizeError(null, response);
+            }
+            return response;
+        } catch (err) {
+            if (err && err.kind) {
+                throw err;
+            }
+            throw errors.normalizeError(err, err && err.response ? err.response : null);
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    async function apiJson(path, opts = {}) {
+        const response = await apiFetch(path, opts);
+        try {
+            return await response.json();
+        } catch (err) {
+            throw errors.normalizeError(err, response);
+        }
+    }
+
+    async function apiText(path, opts = {}) {
+        const response = await apiFetch(path, opts);
+        try {
+            return await response.text();
+        } catch (err) {
+            throw errors.normalizeError(err, response);
+        }
+    }
+
+    function apiDownloadUrl(path) {
+        return buildUrl(path);
+    }
+
+    async function bootstrapSettings() {
+        if (storage.getApiBase()) return storage.getApiBase();
+        try {
+            const response = await fetch('config.json', { cache: 'no-store' });
+            if (!response.ok) return '';
+            const config = await response.json();
+            if (config.apiBase) {
+                storage.setApiBase(config.apiBase);
+                return config.apiBase;
+            }
+        } catch (err) {
+            return '';
+        }
+        return '';
+    }
+
+    async function ensureCapability(key) {
+        const caps = await capabilities.getCapabilities();
+        if (caps && caps.endpoints && caps.endpoints[key] === false) {
+            throw errors.normalizeError({ kind: 'NOT_IMPLEMENTED', message: 'Endpoint not implemented' }, { status: 404 });
+        }
+    }
+
+    async function listRuns() {
+        await ensureCapability('runs_list');
+        const data = await apiJson('/api/runs?limit=50');
+        return data.runs || data.data || [];
+    }
+
+    async function getRun(runId) {
+        await ensureCapability('run_detail');
+        return await apiJson(`/api/runs/${encodeURIComponent(runId)}`);
+    }
+
+    async function getRunFiles(runId) {
+        try {
+            const data = await apiJson(`/api/runs/${encodeURIComponent(runId)}/files`);
+            return data.files || data;
+        } catch (err) {
+            if (err.kind === 'NOT_IMPLEMENTED') {
+                const run = await getRun(runId);
+                return run.files || [];
+            }
+            throw err;
+        }
+    }
+
+    async function getRunFileText(runId, filename) {
+        return await apiText(`/api/runs/${encodeURIComponent(runId)}/files/${encodeURIComponent(filename)}`);
+    }
+
+    async function getRunProgress(runId) {
+        const run = await getRun(runId);
+        return {
+            status: run.status,
+            progress: run.progress || 0,
+            counts: run.counts || {},
+            metrics: run.metrics || {},
+            run
+        };
+    }
+
+    async function getRunEvents(runId) {
+        try {
+            await ensureCapability('run_events');
+            return await apiJson(`/api/runs/${encodeURIComponent(runId)}/events?tail=200`);
+        } catch (err) {
+            if (err.kind === 'NOT_IMPLEMENTED') {
+                return {
+                    events: [],
+                    poll: true,
+                    run: await getRun(runId)
+                };
+            }
+            throw err;
+        }
+    }
+
+    async function getRank(runId, topK, query) {
+        return fallbacks.resolveWithFallback({
+            apiFn: async () => {
+                await ensureCapability('research_rank');
+                return await apiJson(`/api/research/rank?run_id=${encodeURIComponent(runId)}&q=${encodeURIComponent(query || '')}&top_k=${topK || 50}&mode=hybrid`);
+            },
+            fileFn: async () => {
+                const text = await getRunFileText(runId, 'research_rank.json');
+                return JSON.parse(text);
+            },
+            noneFn: async () => ({ results: [], status: 'NOT_IMPLEMENTED' })
+        });
+    }
+
+    async function getPaperClaims(runId, paperId) {
+        return fallbacks.resolveWithFallback({
+            apiFn: async () => {
+                await ensureCapability('research_paper');
+                return await apiJson(`/api/research/paper/${encodeURIComponent(paperId)}?run_id=${encodeURIComponent(runId)}`);
+            },
+            fileFn: async () => {
+                const text = await getRunFileText(runId, `claims/${paperId}.claims.jsonl`);
+                return { claims: parsers.parseJsonl(text) };
+            },
+            noneFn: async () => ({ claims: [], status: 'NOT_IMPLEMENTED' })
+        });
+    }
+
+    async function getQAReport(runId) {
+        return fallbacks.resolveWithFallback({
+            apiFn: async () => {
+                await ensureCapability('qa_report');
+                return await apiJson(`/api/qa/report?run_id=${encodeURIComponent(runId)}`);
+            },
+            fileFn: async () => {
+                try {
+                    const jsonText = await getRunFileText(runId, 'qa_report.json');
+                    return { format: 'json', data: JSON.parse(jsonText) };
+                } catch (err) {
+                    const mdText = await getRunFileText(runId, 'qa_report.md');
+                    return { format: 'markdown', data: mdText };
+                }
+            },
+            noneFn: async () => ({ format: 'none', data: null, status: 'NOT_IMPLEMENTED' })
+        });
+    }
+
+    async function getExportLinks(runId) {
+        const files = await getRunFiles(runId);
+        const artifacts = parsers.inferArtifacts(files);
+        const links = [];
+        const mapping = {
+            packageZip: 'package.zip',
+            notesZip: 'notes.zip',
+            draftsDocx: 'drafts.docx',
+            slidesPptx: 'slides.pptx',
+            manifest: 'manifest.json'
+        };
+        Object.entries(artifacts).forEach(([key, file]) => {
+            if (file && file.name) {
+                links.push({
+                    label: mapping[key] || file.name,
+                    filename: file.name,
+                    url: apiDownloadUrl(`/api/runs/${encodeURIComponent(runId)}/files/${encodeURIComponent(file.name)}`)
+                });
+            }
+        });
+        return links;
+    }
+
+    async function buildSubmission(runId, payload) {
+        await ensureCapability('submission_build');
+        return await apiJson(`/api/submission/build?run_id=${encodeURIComponent(runId)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload || {})
+        });
+    }
+
+    async function getSubmissionLatest(runId) {
+        try {
+            await ensureCapability('submission_build');
+            return await apiJson(`/api/submission/latest?run_id=${encodeURIComponent(runId)}`);
+        } catch (err) {
+            const files = await getRunFiles(runId);
+            const submission = parsers.findByNameContains(files, 'submission') || parsers.findBySuffix(files, '.zip');
+            return submission ? {
+                filename: submission.name,
+                url: apiDownloadUrl(`/api/runs/${encodeURIComponent(runId)}/files/${encodeURIComponent(submission.name)}`)
+            } : null;
+        }
+    }
+
+    async function getFeedbackRisk(runId) {
+        await ensureCapability('feedback_risk');
+        return await apiJson(`/api/feedback/risk?run_id=${encodeURIComponent(runId)}`);
+    }
+
+    async function importFeedback(text, meta) {
+        await ensureCapability('feedback_risk');
+        return await apiJson('/api/feedback/import', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text, meta })
+        });
+    }
+
+    async function simulateDecision(input) {
+        await ensureCapability('decision_simulate');
+        return await apiJson('/api/decision/simulate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input || {})
+        });
+    }
+
+    async function optimizeFinance(input) {
+        await ensureCapability('finance_optimize');
+        return await apiJson('/api/finance/optimize', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input || {})
+        });
+    }
+
+    async function simulateFinance(input) {
+        await ensureCapability('finance_optimize');
+        return await apiJson('/api/finance/simulate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input || {})
+        });
+    }
+
+    async function listJobs(payload) {
+        return await apiJson('/api/jobs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload || {})
+        });
+    }
+
+    async function getJob(jobId) {
+        return await apiJson(`/api/jobs/${encodeURIComponent(jobId)}`);
+    }
+
+    async function getJobEvents(jobId) {
+        return await apiJson(`/api/jobs/${encodeURIComponent(jobId)}/events?tail=200`);
+    }
+
+    async function searchCorpus(query, topK) {
+        return await apiJson(`/api/search?q=${encodeURIComponent(query)}&top_k=${topK || 20}`);
+    }
+
+    async function uploadFiles(endpoint, files) {
+        const formData = new FormData();
+        for (const file of files) {
+            formData.append('files', file);
+        }
+        return await apiJson(endpoint, {
+            method: 'POST',
+            body: formData
+        });
+    }
+
+    function getManifestUrl(runId) {
+        return apiDownloadUrl(`/api/runs/${encodeURIComponent(runId)}/manifest`);
+    }
+
+    global.JarvisApp = {
+        apiFetch,
+        apiJson,
+        apiText,
+        apiDownloadUrl,
+        bootstrapSettings,
+        listRuns,
+        getRun,
+        getRunFiles,
+        getRunFileText,
+        getRunProgress,
+        getRunEvents,
+        getRank,
+        getPaperClaims,
+        getQAReport,
+        getExportLinks,
+        buildSubmission,
+        getSubmissionLatest,
+        getFeedbackRisk,
+        importFeedback,
+        simulateDecision,
+        optimizeFinance,
+        simulateFinance,
+        listJobs,
+        getJob,
+        getJobEvents,
+        searchCorpus,
+        uploadFiles,
+        getManifestUrl
+    };
+})(window);

--- a/dashboard/assets/capabilities.js
+++ b/dashboard/assets/capabilities.js
@@ -1,0 +1,111 @@
+(function (global) {
+    const CACHE_TTL_MS = 5 * 60 * 1000;
+
+    const ENDPOINTS = {
+        health: '/api/health',
+        runs_list: '/api/runs',
+        run_detail: '/api/runs/{id}',
+        run_events: '/api/runs/{id}/events',
+        research_rank: '/api/research/rank',
+        research_paper: '/api/research/paper/{paper_id}',
+        qa_report: '/api/qa/report',
+        export_package: '/api/export/run/{id}/package',
+        submission_build: '/api/submission/build',
+        feedback_risk: '/api/feedback/risk',
+        decision_simulate: '/api/decision/simulate',
+        finance_optimize: '/api/finance/optimize'
+    };
+
+    function buildUrl(path) {
+        const base = global.JarvisStorage.getApiBase();
+        if (!base) return path;
+        return `${base.replace(/\/$/, '')}${path}`;
+    }
+
+    async function fetchWithMethod(url, method, headers) {
+        try {
+            const res = await fetch(url, { method, headers });
+            return res;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    async function checkEndpoint(path) {
+        const token = global.JarvisStorage.getToken();
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        const url = buildUrl(path);
+        let res = await fetchWithMethod(url, 'HEAD', headers);
+        if (!res || res.status === 405 || res.status === 400) {
+            res = await fetchWithMethod(url, 'GET', headers);
+        }
+        if (!res) return false;
+        if (res.status === 401 || res.status === 403) return true;
+        if (res.status === 404 || res.status === 501) return false;
+        return res.status < 500;
+    }
+
+    async function resolveRunId() {
+        try {
+            const url = buildUrl('/api/runs?limit=1');
+            const token = global.JarvisStorage.getToken();
+            const headers = token ? { Authorization: `Bearer ${token}` } : {};
+            const res = await fetch(url, { headers });
+            if (!res.ok) return null;
+            const data = await res.json();
+            const run = data.runs && data.runs.length ? data.runs[0] : null;
+            return run ? run.run_id : null;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    async function getCapabilities(force = false) {
+        if (!force) {
+            const cached = global.JarvisStorage.getCapCache();
+            if (cached) return cached;
+        }
+
+        const result = {
+            checkedAt: new Date().toISOString(),
+            endpoints: {}
+        };
+
+        result.endpoints.health = await checkEndpoint(ENDPOINTS.health);
+        result.endpoints.runs_list = await checkEndpoint(ENDPOINTS.runs_list);
+
+        let runId = null;
+        if (result.endpoints.runs_list) {
+            runId = await resolveRunId();
+        }
+
+        const runDetailPath = runId ? `/api/runs/${runId}` : null;
+        const runEventsPath = runId ? `/api/runs/${runId}/events` : null;
+
+        result.endpoints.run_detail = runDetailPath ? await checkEndpoint(runDetailPath) : result.endpoints.runs_list;
+        result.endpoints.run_events = runEventsPath ? await checkEndpoint(runEventsPath) : result.endpoints.runs_list;
+
+        const remaining = {
+            research_rank: ENDPOINTS.research_rank,
+            research_paper: ENDPOINTS.research_paper.replace('{paper_id}', 'sample'),
+            qa_report: ENDPOINTS.qa_report,
+            export_package: ENDPOINTS.export_package.replace('{id}', 'sample'),
+            submission_build: ENDPOINTS.submission_build,
+            feedback_risk: ENDPOINTS.feedback_risk,
+            decision_simulate: ENDPOINTS.decision_simulate,
+            finance_optimize: ENDPOINTS.finance_optimize
+        };
+
+        for (const [key, path] of Object.entries(remaining)) {
+            result.endpoints[key] = await checkEndpoint(path);
+        }
+
+        global.JarvisStorage.setCapCache(result, CACHE_TTL_MS);
+        return result;
+    }
+
+    global.JarvisCapabilities = {
+        getCapabilities,
+        ENDPOINTS
+    };
+})(window);

--- a/dashboard/assets/errors.js
+++ b/dashboard/assets/errors.js
@@ -1,0 +1,61 @@
+(function (global) {
+    function normalizeError(err, response) {
+        if (err && err.kind) {
+            return err;
+        }
+
+        const status = response && response.status ? response.status : 0;
+        let kind = 'SERVER_ERROR';
+        let message = 'Unexpected error';
+        let detail = '';
+        let hint = '';
+
+        if (err && err.name === 'AbortError') {
+            kind = 'TIMEOUT';
+            message = 'Request timed out';
+            hint = 'ネットワーク状況を確認してください。';
+        } else if (!response && err instanceof TypeError) {
+            kind = 'NO_CONNECTION';
+            message = 'Network request failed';
+            hint = 'APIサーバに接続できません。';
+        } else if (err instanceof SyntaxError) {
+            kind = 'BAD_RESPONSE';
+            message = 'Failed to parse response';
+            hint = 'サーバのレスポンス形式が不正です。';
+        } else if (status === 401 || status === 403) {
+            kind = 'UNAUTHORIZED';
+            message = 'Unauthorized';
+            hint = 'Settingsでトークンを設定してください。';
+        } else if (status === 404 || status === 501) {
+            kind = 'NOT_IMPLEMENTED';
+            message = 'Endpoint not implemented';
+            hint = '代替の成果物ファイルを確認してください。';
+        } else if (status >= 500) {
+            kind = 'SERVER_ERROR';
+            message = 'Server error';
+            hint = 'サーバの状態を確認してください。';
+        } else if (status > 0 && status < 500) {
+            kind = 'BAD_RESPONSE';
+            message = 'Bad response';
+        } else if (!response && err) {
+            kind = 'NO_CONNECTION';
+            message = 'Network error';
+        }
+
+        if (err && err.message) {
+            detail = err.message;
+        }
+
+        return {
+            kind,
+            status,
+            message,
+            detail,
+            hint
+        };
+    }
+
+    global.JarvisErrors = {
+        normalizeError
+    };
+})(window);

--- a/dashboard/assets/fallbacks.js
+++ b/dashboard/assets/fallbacks.js
@@ -1,0 +1,28 @@
+(function (global) {
+    async function resolveWithFallback({ apiFn, fileFn, noneFn }) {
+        try {
+            return await apiFn();
+        } catch (err) {
+            if (err && err.kind === 'NOT_IMPLEMENTED') {
+                if (fileFn) {
+                    try {
+                        return await fileFn();
+                    } catch (fileErr) {
+                        if (noneFn) {
+                            return await noneFn();
+                        }
+                        throw fileErr;
+                    }
+                }
+                if (noneFn) {
+                    return await noneFn();
+                }
+            }
+            throw err;
+        }
+    }
+
+    global.JarvisFallbacks = {
+        resolveWithFallback
+    };
+})(window);

--- a/dashboard/assets/parsers.js
+++ b/dashboard/assets/parsers.js
@@ -1,0 +1,88 @@
+(function (global) {
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function parseJsonl(text) {
+        if (!text) return [];
+        return text
+            .split(/\r?\n/)
+            .map(line => line.trim())
+            .filter(Boolean)
+            .map(line => {
+                try {
+                    return JSON.parse(line);
+                } catch (err) {
+                    return null;
+                }
+            })
+            .filter(Boolean);
+    }
+
+    function renderMarkdownPreview(text) {
+        if (!text) return '';
+        return escapeHtml(text).replace(/\r?\n/g, '<br>');
+    }
+
+    function normalizeFiles(files) {
+        if (!files) return [];
+        if (Array.isArray(files)) {
+            return files.map((item) => {
+                if (typeof item === 'string') {
+                    return { name: item };
+                }
+                if (item && typeof item === 'object') {
+                    return {
+                        name: item.name || item.filename || item.path || '',
+                        url: item.url || item.download_url || null,
+                        exists: item.exists
+                    };
+                }
+                return null;
+            }).filter(Boolean);
+        }
+        if (typeof files === 'object') {
+            return Object.entries(files)
+                .map(([name, info]) => ({
+                    name,
+                    exists: info && typeof info === 'object' ? info.exists : true,
+                    size: info && typeof info === 'object' ? info.size : null
+                }))
+                .filter(item => item.exists !== false);
+        }
+        return [];
+    }
+
+    function findBySuffix(files, suffix) {
+        const list = normalizeFiles(files);
+        return list.find(item => item.name && item.name.endsWith(suffix)) || null;
+    }
+
+    function findByNameContains(files, token) {
+        const list = normalizeFiles(files);
+        const lowered = token.toLowerCase();
+        return list.find(item => item.name && item.name.toLowerCase().includes(lowered)) || null;
+    }
+
+    function inferArtifacts(files) {
+        return {
+            packageZip: findByNameContains(files, 'package') || findBySuffix(files, 'package.zip'),
+            notesZip: findByNameContains(files, 'notes') || findBySuffix(files, 'notes.zip'),
+            draftsDocx: findBySuffix(files, '.docx'),
+            slidesPptx: findBySuffix(files, '.pptx'),
+            manifest: findByNameContains(files, 'manifest') || findBySuffix(files, '.json')
+        };
+    }
+
+    global.JarvisParsers = {
+        escapeHtml,
+        parseJsonl,
+        renderMarkdownPreview,
+        normalizeFiles,
+        findBySuffix,
+        findByNameContains,
+        inferArtifacts
+    };
+})(window);

--- a/dashboard/assets/storage.js
+++ b/dashboard/assets/storage.js
@@ -1,0 +1,85 @@
+(function (global) {
+    const KEY_API_BASE = 'JAVIS_API_BASE';
+    const KEY_API_TOKEN = 'JAVIS_API_TOKEN';
+    const KEY_CAP_CACHE = 'JAVIS_CAP_CACHE';
+    const KEY_LAST_RUN = 'JAVIS_LAST_RUN';
+
+    function getApiBase() {
+        return (localStorage.getItem(KEY_API_BASE) || '').trim();
+    }
+
+    function setApiBase(value) {
+        if (value === null || value === undefined) {
+            localStorage.removeItem(KEY_API_BASE);
+            return;
+        }
+        localStorage.setItem(KEY_API_BASE, String(value).trim());
+    }
+
+    function getToken() {
+        return (localStorage.getItem(KEY_API_TOKEN) || '').trim();
+    }
+
+    function setToken(value) {
+        if (value === null || value === undefined) {
+            localStorage.removeItem(KEY_API_TOKEN);
+            return;
+        }
+        localStorage.setItem(KEY_API_TOKEN, String(value).trim());
+    }
+
+    function getCapCache() {
+        const raw = localStorage.getItem(KEY_CAP_CACHE);
+        if (!raw) return null;
+        try {
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object') return null;
+            if (parsed.expiresAt && Date.now() > parsed.expiresAt) {
+                localStorage.removeItem(KEY_CAP_CACHE);
+                return null;
+            }
+            return parsed.value || null;
+        } catch (err) {
+            localStorage.removeItem(KEY_CAP_CACHE);
+            return null;
+        }
+    }
+
+    function setCapCache(value, ttlMs) {
+        const payload = {
+            value,
+            expiresAt: ttlMs ? Date.now() + ttlMs : null
+        };
+        localStorage.setItem(KEY_CAP_CACHE, JSON.stringify(payload));
+    }
+
+    function clearAllSettings() {
+        [KEY_API_BASE, KEY_API_TOKEN, KEY_CAP_CACHE, KEY_LAST_RUN].forEach((key) => {
+            localStorage.removeItem(key);
+        });
+    }
+
+    function getLastRun() {
+        return (localStorage.getItem(KEY_LAST_RUN) || '').trim();
+    }
+
+    function setLastRun(value) {
+        if (value === null || value === undefined) {
+            localStorage.removeItem(KEY_LAST_RUN);
+            return;
+        }
+        localStorage.setItem(KEY_LAST_RUN, String(value).trim());
+    }
+
+    global.JarvisStorage = {
+        getApiBase,
+        setApiBase,
+        getToken,
+        setToken,
+        getCapCache,
+        setCapCache,
+        clearAllSettings,
+        getLastRun,
+        setLastRun
+    };
+})(window);

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -1,0 +1,137 @@
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background: rgba(255, 255, 255, 0.08);
+    color: #e8e8e8;
+}
+
+.status-READY {
+    color: #00ff88;
+    border: 1px solid rgba(0, 255, 136, 0.4);
+}
+
+.status-BLOCKED,
+.status-NO_CONNECTION {
+    color: #ffaa00;
+    border: 1px solid rgba(255, 170, 0, 0.4);
+}
+
+.status-UNAUTHORIZED {
+    color: #ff4444;
+    border: 1px solid rgba(255, 68, 68, 0.4);
+}
+
+.status-NOT_IMPLEMENTED {
+    color: #a0a0a0;
+    border: 1px dashed rgba(160, 160, 160, 0.6);
+}
+
+.error-panel {
+    background: rgba(255, 68, 68, 0.1);
+    border: 1px solid rgba(255, 68, 68, 0.4);
+    padding: 12px 16px;
+    border-radius: 12px;
+    margin: 12px 0;
+}
+
+.error-header {
+    font-weight: 700;
+    color: #ff6666;
+}
+
+.error-message {
+    margin-top: 6px;
+    color: #f1f1f1;
+}
+
+.error-detail {
+    font-size: 0.85em;
+    color: #ffaa00;
+    margin-top: 6px;
+}
+
+.error-hint {
+    font-size: 0.85em;
+    color: #a0a0a0;
+    margin-top: 6px;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 12px;
+    border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.empty-state h3 {
+    margin-bottom: 8px;
+}
+
+.empty-actions {
+    margin-top: 12px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.toast {
+    position: fixed;
+    right: 20px;
+    top: 20px;
+    background: rgba(15, 15, 35, 0.95);
+    border-left: 4px solid #00d4ff;
+    padding: 12px 16px;
+    border-radius: 10px;
+    color: #e8e8e8;
+    z-index: 1000;
+}
+
+.toast-success {
+    border-left-color: #00ff88;
+}
+
+.toast-warning {
+    border-left-color: #ffaa00;
+}
+
+.toast-danger {
+    border-left-color: #ff4444;
+}
+
+.settings-card {
+    background: rgba(0, 212, 255, 0.05);
+    border: 1px solid rgba(0, 212, 255, 0.2);
+    padding: 16px;
+    border-radius: 12px;
+}
+
+.settings-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.settings-row input {
+    flex: 1;
+    min-width: 220px;
+}
+
+.status-strip {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.status-label {
+    color: #a0a0a0;
+    font-size: 0.85em;
+}

--- a/dashboard/assets/ui.js
+++ b/dashboard/assets/ui.js
@@ -1,0 +1,55 @@
+(function (global) {
+    function renderStatusBadge(kind) {
+        const labelMap = {
+            READY: 'READY',
+            BLOCKED: 'BLOCKED',
+            UNAUTHORIZED: 'UNAUTHORIZED',
+            NO_CONNECTION: 'NO_CONNECTION',
+            NOT_IMPLEMENTED: 'NOT_IMPLEMENTED'
+        };
+        const label = labelMap[kind] || kind;
+        return `<span class="status-badge status-${kind}">${label}</span>`;
+    }
+
+    function renderErrorPanel(normalizedError) {
+        if (!normalizedError) return '';
+        const hint = normalizedError.hint ? `<div class="error-hint">${normalizedError.hint}</div>` : '';
+        const detail = normalizedError.detail ? `<div class="error-detail">${normalizedError.detail}</div>` : '';
+        return `
+            <div class="error-panel">
+                <div class="error-header">${normalizedError.kind || 'ERROR'} (${normalizedError.status || '-'})</div>
+                <div class="error-message">${normalizedError.message || ''}</div>
+                ${detail}
+                ${hint}
+            </div>
+        `;
+    }
+
+    function toast(message, type = 'info') {
+        const toastEl = document.createElement('div');
+        toastEl.className = `toast toast-${type}`;
+        toastEl.textContent = message;
+        document.body.appendChild(toastEl);
+        setTimeout(() => toastEl.remove(), 3200);
+    }
+
+    function renderEmptyState(title, message, actions = []) {
+        const actionHtml = actions.map(action => {
+            return `<button class="btn btn-secondary" data-action="${action.id}">${action.label}</button>`;
+        }).join('');
+        return `
+            <div class="empty-state">
+                <h3>${title}</h3>
+                <p>${message}</p>
+                <div class="empty-actions">${actionHtml}</div>
+            </div>
+        `;
+    }
+
+    global.JarvisUI = {
+        renderStatusBadge,
+        renderErrorPanel,
+        toast,
+        renderEmptyState
+    };
+})(window);

--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -127,6 +127,7 @@
             font-size: 0.9em;
         }
     </style>
+    <link rel="stylesheet" href="assets/styles.css">
 </head>
 
 <body>
@@ -135,6 +136,24 @@
             <h1>Resource Optimization (P10)</h1>
             <p class="note">すべての結果は仮定依存（推測）として表示されます。</p>
         </header>
+        <div class="status-strip">
+            <span class="status-label">Connection</span>
+            <span id="status-badges"></span>
+        </div>
+        <div id="global-error"></div>
+
+        <div class="card settings-card">
+            <h2>⚙️ API Settings</h2>
+            <div class="settings-row" style="margin-top: 12px;">
+                <input type="text" id="api-base-input" placeholder="https://xxxx.workers.dev">
+                <input type="password" id="api-token-input" placeholder="API Token">
+            </div>
+            <div style="margin-top: 12px; display: flex; gap: 10px; flex-wrap: wrap;">
+                <button id="save-settings-btn">保存</button>
+                <button class="secondary" id="clear-settings-btn">クリア</button>
+                <button class="secondary" id="refresh-cap-btn">再チェック</button>
+            </div>
+        </div>
 
         <div class="card">
             <h2>シナリオ比較</h2>
@@ -163,11 +182,65 @@
         </div>
     </div>
 
+    <script src="assets/storage.js"></script>
+    <script src="assets/errors.js"></script>
+    <script src="assets/parsers.js"></script>
+    <script src="assets/fallbacks.js"></script>
+    <script src="assets/capabilities.js"></script>
+    <script src="assets/app.js"></script>
+    <script src="assets/ui.js"></script>
     <script>
-        const apiBase = '';
+        const storage = window.JarvisStorage;
+        const app = window.JarvisApp;
+        const ui = window.JarvisUI;
+        const errors = window.JarvisErrors;
+
         const scenarioCards = document.getElementById('scenario-cards');
         const cashflowBody = document.getElementById('cashflow-body');
         const optimizeNote = document.getElementById('optimize-note');
+
+        function updateStatusBadge(kind) {
+            document.getElementById('status-badges').innerHTML = ui.renderStatusBadge(kind);
+        }
+
+        function setGlobalError(err) {
+            document.getElementById('global-error').innerHTML = err ? ui.renderErrorPanel(err) : '';
+            if (err) {
+                const kind = err.kind === 'UNAUTHORIZED' ? 'UNAUTHORIZED' : err.kind === 'NO_CONNECTION' ? 'NO_CONNECTION' : err.kind === 'NOT_IMPLEMENTED' ? 'NOT_IMPLEMENTED' : 'BLOCKED';
+                updateStatusBadge(kind);
+            }
+        }
+
+        async function refreshCapabilities() {
+            try {
+                const caps = await window.JarvisCapabilities.getCapabilities(true);
+                updateStatusBadge(caps.endpoints.health ? 'READY' : 'NO_CONNECTION');
+            } catch (err) {
+                setGlobalError(err);
+            }
+        }
+
+        async function initSettings() {
+            await app.bootstrapSettings();
+            document.getElementById('api-base-input').value = storage.getApiBase();
+            document.getElementById('api-token-input').value = storage.getToken();
+        }
+
+        function saveSettings() {
+            storage.setApiBase(document.getElementById('api-base-input').value);
+            storage.setToken(document.getElementById('api-token-input').value);
+            localStorage.removeItem('JAVIS_CAP_CACHE');
+            refreshCapabilities();
+            ui.toast('設定を保存しました', 'success');
+        }
+
+        function clearSettings() {
+            storage.clearAllSettings();
+            document.getElementById('api-base-input').value = '';
+            document.getElementById('api-token-input').value = '';
+            refreshCapabilities();
+            ui.toast('設定をクリアしました', 'warning');
+        }
 
         function statusBadge(status) {
             if (status === 'feasible') return 'success';
@@ -210,33 +283,44 @@
         }
 
         async function loadSimulation() {
-            const response = await fetch(`${apiBase}/api/finance/simulate`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ months: 36 })
-            });
-            const data = await response.json();
-            renderScenarios(data.scenarios || []);
+            try {
+                const data = await app.simulateFinance({ months: 36 });
+                renderScenarios(data.scenarios || []);
+                setGlobalError(null);
+            } catch (err) {
+                const normalized = errors.normalizeError(err, err && err.response);
+                scenarioCards.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
+            }
         }
 
         async function runOptimize() {
-            const response = await fetch(`${apiBase}/api/finance/optimize`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ months: 36 })
-            });
-            const data = await response.json();
-            optimizeNote.textContent = `推奨シナリオ: ${data.scenario} (${data.status}) - ${data.recommendation}`;
+            try {
+                const data = await app.optimizeFinance({ months: 36 });
+                optimizeNote.textContent = `推奨シナリオ: ${data.scenario} (${data.status}) - ${data.recommendation}`;
+                setGlobalError(null);
+            } catch (err) {
+                const normalized = errors.normalizeError(err, err && err.response);
+                optimizeNote.textContent = '';
+                setGlobalError(normalized);
+                ui.toast('最適化に失敗しました', 'danger');
+            }
         }
 
         async function downloadReport() {
-            window.location.href = `${apiBase}/api/finance/download?format=zip`;
+            window.location.href = app.apiDownloadUrl('/api/finance/download?format=zip');
         }
 
         document.getElementById('optimize-btn').addEventListener('click', runOptimize);
         document.getElementById('download-btn').addEventListener('click', downloadReport);
+        document.getElementById('save-settings-btn').addEventListener('click', saveSettings);
+        document.getElementById('clear-settings-btn').addEventListener('click', clearSettings);
+        document.getElementById('refresh-cap-btn').addEventListener('click', refreshCapabilities);
 
-        loadSimulation();
+        initSettings().then(() => {
+            refreshCapabilities();
+            loadSimulation();
+        });
     </script>
 </body>
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -555,6 +555,7 @@
             font-size: 0.9em;
         }
     </style>
+    <link rel="stylesheet" href="assets/styles.css">
 </head>
 
 <body>
@@ -570,6 +571,11 @@
                 <button class="btn btn-primary" onclick="showTab('new-query')">+ 新規クエリ</button>
             </div>
         </header>
+        <div class="status-strip">
+            <span class="status-label">Connection</span>
+            <span id="status-badges"></span>
+        </div>
+        <div id="global-error"></div>
 
         <!-- Navigation -->
         <div class="nav-tabs">
@@ -580,6 +586,7 @@
             <div class="nav-tab" onclick="showTab('upload')">📁 アップロード</div>
             <div class="nav-tab" onclick="showTab('research')">🏷️ Research</div>
             <div class="nav-tab" onclick="showTab('runs')">📋 実行履歴</div>
+            <div class="nav-tab" onclick="showTab('settings')">⚙️ Settings</div>
         </div>
 
         <!-- KPI Grid (S-02: Fixed Definition) -->
@@ -786,6 +793,22 @@
             </div>
         </div>
 
+        <div id="tab-settings" class="tab-content">
+            <div class="section settings-card">
+                <h2>⚙️ API Settings</h2>
+                <p style="color: var(--text-secondary); margin: 8px 0 16px;">API Base / Token を設定すると認証が復旧します。</p>
+                <div class="settings-row">
+                    <input type="text" id="api-base-input" placeholder="https://xxxx.workers.dev">
+                    <input type="password" id="api-token-input" placeholder="API Token">
+                </div>
+                <div style="margin-top: 12px; display: flex; gap: 10px; flex-wrap: wrap;">
+                    <button class="btn btn-primary" onclick="saveSettings()">保存</button>
+                    <button class="btn btn-secondary" onclick="clearSettings()">クリア</button>
+                    <button class="btn btn-secondary" onclick="refreshCapabilities()">再チェック</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Run Detail Modal -->
         <div class="modal" id="run-modal">
             <div class="modal-content">
@@ -799,8 +822,19 @@
         </footer>
     </div>
 
+    <script src="assets/storage.js"></script>
+    <script src="assets/errors.js"></script>
+    <script src="assets/parsers.js"></script>
+    <script src="assets/fallbacks.js"></script>
+    <script src="assets/capabilities.js"></script>
+    <script src="assets/app.js"></script>
+    <script src="assets/ui.js"></script>
     <script>
-        let API_BASE = '';
+        const storage = window.JarvisStorage;
+        const app = window.JarvisApp;
+        const ui = window.JarvisUI;
+        const errors = window.JarvisErrors;
+
         let runs = [];
         let currentTab = 'overview';
         let currentJobId = null;
@@ -809,16 +843,58 @@
         let researchResults = [];
         let tierFilter = 'all';
 
-        async function loadConfig() {
+        function statusKindFromError(err) {
+            if (!err) return 'READY';
+            if (err.kind === 'NO_CONNECTION') return 'NO_CONNECTION';
+            if (err.kind === 'UNAUTHORIZED') return 'UNAUTHORIZED';
+            if (err.kind === 'NOT_IMPLEMENTED') return 'NOT_IMPLEMENTED';
+            return 'BLOCKED';
+        }
+
+        function updateStatusBadge(kind) {
+            const container = document.getElementById('status-badges');
+            container.innerHTML = ui.renderStatusBadge(kind);
+        }
+
+        function setGlobalError(err) {
+            const container = document.getElementById('global-error');
+            container.innerHTML = err ? ui.renderErrorPanel(err) : '';
+            updateStatusBadge(statusKindFromError(err));
+        }
+
+        async function refreshCapabilities() {
             try {
-                const res = await fetch('config.json', { cache: 'no-store' });
-                if (res.ok) {
-                    const config = await res.json();
-                    API_BASE = config.apiBase || '';
+                const caps = await window.JarvisCapabilities.getCapabilities(true);
+                if (!caps.endpoints.health) {
+                    updateStatusBadge('NO_CONNECTION');
+                } else {
+                    updateStatusBadge('READY');
                 }
-            } catch (e) {
-                API_BASE = '';
+            } catch (err) {
+                setGlobalError(err);
             }
+        }
+
+        async function initSettings() {
+            await app.bootstrapSettings();
+            document.getElementById('api-base-input').value = storage.getApiBase();
+            document.getElementById('api-token-input').value = storage.getToken();
+        }
+
+        function saveSettings() {
+            storage.setApiBase(document.getElementById('api-base-input').value);
+            storage.setToken(document.getElementById('api-token-input').value);
+            localStorage.removeItem('JAVIS_CAP_CACHE');
+            refreshCapabilities();
+            ui.toast('設定を保存しました', 'success');
+        }
+
+        function clearSettings() {
+            storage.clearAllSettings();
+            document.getElementById('api-base-input').value = '';
+            document.getElementById('api-token-input').value = '';
+            refreshCapabilities();
+            ui.toast('設定をクリアしました', 'warning');
         }
 
         // === Tab Navigation ===
@@ -850,20 +926,19 @@
             const query = document.getElementById('research-query').value.trim();
             const topK = document.getElementById('research-top-k').value || 50;
             if (!runId) {
-                document.getElementById('research-results').innerHTML = '<p>run_id がありません。</p>';
+                document.getElementById('research-results').innerHTML = ui.renderEmptyState('run_id がありません', 'Runsからrun_idを選択してください。');
                 return;
             }
 
             try {
-                const res = await fetch(`${API_BASE}/api/research/rank?run_id=${runId}&q=${encodeURIComponent(query)}&top_k=${topK}&mode=hybrid`);
-                if (!res.ok) {
-                    throw new Error(await res.text());
-                }
-                const payload = await res.json();
+                const payload = await app.getRank(runId, topK, query);
                 researchResults = payload.results || [];
                 renderResearchResults();
+                setGlobalError(null);
             } catch (err) {
-                document.getElementById('research-results').innerHTML = `<p style="color: var(--danger);">rank failed: ${err}</p>`;
+                const normalized = errors.normalizeError(err, err && err.response);
+                document.getElementById('research-results').innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -875,7 +950,7 @@
         function renderResearchResults() {
             const container = document.getElementById('research-results');
             if (!researchResults.length) {
-                container.innerHTML = '<p>結果がありません。</p>';
+                container.innerHTML = ui.renderEmptyState('結果がありません', 'API または成果物ファイルを確認してください。');
                 return;
             }
             const filtered = tierFilter === 'all'
@@ -925,7 +1000,7 @@
                 alert('run_id がありません');
                 return;
             }
-            window.open(`${API_BASE}/api/runs/${runId}/manifest`, '_blank');
+            window.open(app.getManifestUrl(runId), '_blank');
         }
 
         // === KPI Update (S-02: Fixed Definition) ===
@@ -957,16 +1032,16 @@
         // === Load Runs ===
         async function loadRuns() {
             try {
-                const res = await fetch(`${API_BASE}/api/runs?limit=50`);
-                if (!res.ok) throw new Error('API error');
-                const data = await res.json();
-                runs = data.runs || [];
+                runs = await app.listRuns();
                 renderRecentRuns();
                 renderRunsTable();
                 updateKPIs();
+                setGlobalError(null);
             } catch (e) {
-                console.error('Failed to load runs:', e);
-                document.getElementById('recent-runs-container').innerHTML = '<p style="color: var(--text-secondary);">データ読み込みエラー</p>';
+                const normalized = errors.normalizeError(e, e && e.response);
+                document.getElementById('recent-runs-container').innerHTML = ui.renderErrorPanel(normalized);
+                document.getElementById('runs-table-container').innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -974,7 +1049,7 @@
         function renderRecentRuns() {
             const container = document.getElementById('recent-runs-container');
             if (runs.length === 0) {
-                container.innerHTML = '<p style="color: var(--text-secondary);">実行履歴がありません</p>';
+                container.innerHTML = ui.renderEmptyState('実行履歴がありません', 'Runが生成されるとここに表示されます。');
                 return;
             }
 
@@ -998,7 +1073,7 @@
         function renderRunsTable() {
             const container = document.getElementById('runs-table-container');
             if (runs.length === 0) {
-                container.innerHTML = '<p style="color: var(--text-secondary);">実行履歴がありません</p>';
+                container.innerHTML = ui.renderEmptyState('実行履歴がありません', 'Runs API または成果物を確認してください。');
                 return;
             }
 
@@ -1031,27 +1106,23 @@
             status.innerHTML = '<div class="spinner"></div><p>パイプライン実行中...</p>';
 
             try {
-                const res = await fetch(`${API_BASE}/api/jobs`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        type: 'collect_and_ingest',
-                        payload: {
-                            query,
-                            max_results: parseInt(document.getElementById('max-papers').value),
-                            oa_only: document.getElementById('oa-only').value === 'true',
-                            domain: document.getElementById('domain-select').value
-                        }
-                    })
+                const result = await app.listJobs({
+                    type: 'collect_and_ingest',
+                    payload: {
+                        query,
+                        max_results: parseInt(document.getElementById('max-papers').value),
+                        oa_only: document.getElementById('oa-only').value === 'true',
+                        domain: document.getElementById('domain-select').value
+                    }
                 });
-
-                const result = await res.json();
                 status.innerHTML = `<p style="color: var(--success);">✅ ジョブ投入: ${result.job_id}</p>`;
-                showToast('ジョブ投入完了', 'success');
+                ui.toast('ジョブ投入完了', 'success');
                 startJobPolling(result.job_id);
             } catch (e) {
-                status.innerHTML = `<p style="color: var(--danger);">❌ エラー: ${e.message}</p>`;
-                showToast('実行エラー', 'danger');
+                const normalized = errors.normalizeError(e, e && e.response);
+                status.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
+                ui.toast('実行エラー', 'danger');
             } finally {
                 btn.disabled = false;
             }
@@ -1066,11 +1137,10 @@
             container.innerHTML = '<div class="spinner"></div>';
 
             try {
-                const res = await fetch(`${API_BASE}/api/search?q=${encodeURIComponent(query)}&top_k=20`);
-                const data = await res.json();
+                const data = await app.searchCorpus(query, 20);
 
                 if (!data.results || data.results.length === 0) {
-                    container.innerHTML = '<p style="color: var(--text-secondary);">結果がありません</p>';
+                    container.innerHTML = ui.renderEmptyState('結果がありません', '検索条件を変えてください。');
                     return;
                 }
 
@@ -1084,7 +1154,9 @@
                     </div>
                 `).join('');
             } catch (e) {
-                container.innerHTML = '<p style="color: var(--danger);">検索エラー</p>';
+                const normalized = errors.normalizeError(e, e && e.response);
+                container.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -1109,25 +1181,21 @@
             status.innerHTML = '<div class="spinner"></div><p>収集中...</p>';
 
             try {
-                const res = await fetch(`${API_BASE}/api/jobs`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        type: 'collect_and_ingest',
-                        payload: {
-                            query,
-                            max_results: parseInt(document.getElementById('collect-max').value),
-                            oa_only: document.getElementById('collect-oa').checked
-                        }
-                    })
+                const result = await app.listJobs({
+                    type: 'collect_and_ingest',
+                    payload: {
+                        query,
+                        max_results: parseInt(document.getElementById('collect-max').value),
+                        oa_only: document.getElementById('collect-oa').checked
+                    }
                 });
-
-                const result = await res.json();
                 status.innerHTML = `<p style="color: var(--success);">✅ ジョブ投入: ${result.job_id}</p>`;
-                showToast('収集ジョブ開始', 'success');
+                ui.toast('収集ジョブ開始', 'success');
                 startJobPolling(result.job_id);
             } catch (e) {
-                status.innerHTML = `<p style="color: var(--danger);">❌ エラー: ${e.message}</p>`;
+                const normalized = errors.normalizeError(e, e && e.response);
+                status.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -1159,13 +1227,13 @@
                 if (files[0].name.endsWith('.bib')) endpoint = '/api/upload/bibtex';
                 else if (files[0].name.endsWith('.zip')) endpoint = '/api/upload/zip';
 
-                const res = await fetch(`${API_BASE}${endpoint}`, { method: 'POST', body: formData });
-                const result = await res.json();
-
+                const result = await app.uploadFiles(endpoint, files);
                 status.innerHTML = `<p style="color: var(--success);">✅ Accepted: ${result.accepted}, Duplicates: ${result.duplicates}, Rejected: ${result.rejected}</p>`;
-                showToast('アップロード完了', 'success');
+                ui.toast('アップロード完了', 'success');
             } catch (e) {
-                status.innerHTML = `<p style="color: var(--danger);">❌ ${e.message}</p>`;
+                const normalized = errors.normalizeError(e, e && e.response);
+                status.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -1177,8 +1245,7 @@
             modal.style.display = 'block';
 
             try {
-                const res = await fetch(`${API_BASE}/api/runs/${runId}`);
-                const run = await res.json();
+                const run = await app.getRun(runId);
 
                 body.innerHTML = `
                     <h2>Run: ${runId}</h2>
@@ -1206,7 +1273,9 @@
                     ${run.report ? `<h3>📝 Report</h3><pre style="max-height: 300px; overflow: auto; background: var(--bg-primary); padding: 15px; border-radius: 8px; white-space: pre-wrap;">${escapeHtml(run.report)}</pre>` : ''}
                 `;
             } catch (e) {
-                body.innerHTML = `<p style="color: var(--danger);">読み込みエラー: ${e.message}</p>`;
+                const normalized = errors.normalizeError(e, e && e.response);
+                body.innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
             }
         }
 
@@ -1216,18 +1285,9 @@
         // === Utilities ===
         function escapeHtml(text) { const d = document.createElement('div'); d.textContent = text; return d.innerHTML; }
 
-        function showToast(message, type = 'info') {
-            const toast = document.createElement('div');
-            toast.className = 'toast';
-            toast.style.borderLeftColor = type === 'success' ? 'var(--success)' : type === 'danger' ? 'var(--danger)' : 'var(--warning)';
-            toast.textContent = message;
-            document.body.appendChild(toast);
-            setTimeout(() => toast.remove(), 3000);
-        }
-
         function refreshAll() {
             loadRuns();
-            showToast('更新しました');
+            ui.toast('更新しました');
         }
 
         function startJobPolling(jobId) {
@@ -1248,9 +1308,7 @@
         async function fetchJobStatus() {
             if (!currentJobId) return;
             try {
-                const res = await fetch(`${API_BASE}/api/jobs/${currentJobId}`);
-                if (!res.ok) return;
-                const job = await res.json();
+                const job = await app.getJob(currentJobId);
                 updateJobCard(job);
                 if (['success', 'failed', 'canceled'].includes(job.status)) {
                     clearInterval(jobPoller);
@@ -1265,9 +1323,7 @@
         async function fetchJobEvents() {
             if (!currentJobId) return;
             try {
-                const res = await fetch(`${API_BASE}/api/jobs/${currentJobId}/events?tail=200`);
-                if (!res.ok) return;
-                const data = await res.json();
+                const data = await app.getJobEvents(currentJobId);
                 const log = document.getElementById('job-log');
                 log.textContent = (data.events || [])
                     .map(ev => `[${ev.timestamp}] ${ev.level || 'info'} ${ev.message || ''}`)
@@ -1293,7 +1349,8 @@
         }
 
         // === Initialize ===
-        loadConfig().then(() => {
+        initSettings().then(() => {
+            refreshCapabilities();
             loadRuns();
         });
     </script>

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -124,11 +124,28 @@
             opacity: 0.8;
         }
     </style>
+    <link rel="stylesheet" href="assets/styles.css">
 </head>
 
 <body>
     <div class="container">
         <h1>📊 JARVIS Runs Dashboard</h1>
+        <div class="status-strip">
+            <span class="status-label">Connection</span>
+            <span id="status-badges"></span>
+        </div>
+        <div id="global-error"></div>
+        <div class="settings-card" style="margin: 16px 0;">
+            <div class="settings-row">
+                <input type="text" id="api-base-input" placeholder="https://xxxx.workers.dev">
+                <input type="password" id="api-token-input" placeholder="API Token">
+            </div>
+            <div style="margin-top: 12px; display: flex; gap: 10px; flex-wrap: wrap;">
+                <button class="refresh-btn" onclick="saveSettings()">保存</button>
+                <button class="refresh-btn" onclick="clearSettings()">クリア</button>
+                <button class="refresh-btn" onclick="refreshCapabilities()">再チェック</button>
+            </div>
+        </div>
         <button class="refresh-btn" onclick="loadRuns()">🔄 Refresh</button>
 
         <div class="runs-grid" id="runs-container">
@@ -157,19 +174,88 @@
         </div>
     </div>
 
+    <script src="assets/storage.js"></script>
+    <script src="assets/errors.js"></script>
+    <script src="assets/parsers.js"></script>
+    <script src="assets/fallbacks.js"></script>
+    <script src="assets/capabilities.js"></script>
+    <script src="assets/app.js"></script>
+    <script src="assets/ui.js"></script>
     <script>
+        const storage = window.JarvisStorage;
+        const app = window.JarvisApp;
+        const ui = window.JarvisUI;
+        const errors = window.JarvisErrors;
+        const parsers = window.JarvisParsers;
+
         const REQUIRED_FILES = [
             'input.json', 'papers.jsonl', 'claims.jsonl',
             'evidence.jsonl', 'scores.json', 'report.md', 'warnings.jsonl'
         ];
 
-        function loadRuns() {
-            // In production: fetch from API
-            console.log('Loading runs...');
+        function updateStatusBadge(kind) {
+            document.getElementById('status-badges').innerHTML = ui.renderStatusBadge(kind);
+        }
+
+        function setGlobalError(err) {
+            const container = document.getElementById('global-error');
+            container.innerHTML = err ? ui.renderErrorPanel(err) : '';
+            if (err) {
+                const kind = err.kind === 'UNAUTHORIZED' ? 'UNAUTHORIZED' : err.kind === 'NO_CONNECTION' ? 'NO_CONNECTION' : err.kind === 'NOT_IMPLEMENTED' ? 'NOT_IMPLEMENTED' : 'BLOCKED';
+                updateStatusBadge(kind);
+            }
+        }
+
+        async function refreshCapabilities() {
+            try {
+                const caps = await window.JarvisCapabilities.getCapabilities(true);
+                updateStatusBadge(caps.endpoints.health ? 'READY' : 'NO_CONNECTION');
+            } catch (err) {
+                setGlobalError(err);
+            }
+        }
+
+        async function initSettings() {
+            await app.bootstrapSettings();
+            document.getElementById('api-base-input').value = storage.getApiBase();
+            document.getElementById('api-token-input').value = storage.getToken();
+        }
+
+        function saveSettings() {
+            storage.setApiBase(document.getElementById('api-base-input').value);
+            storage.setToken(document.getElementById('api-token-input').value);
+            localStorage.removeItem('JAVIS_CAP_CACHE');
+            refreshCapabilities();
+            ui.toast('設定を保存しました', 'success');
+        }
+
+        function clearSettings() {
+            storage.clearAllSettings();
+            document.getElementById('api-base-input').value = '';
+            document.getElementById('api-token-input').value = '';
+            refreshCapabilities();
+            ui.toast('設定をクリアしました', 'warning');
+        }
+
+        async function loadRuns() {
+            try {
+                const runs = await app.listRuns();
+                const container = document.getElementById('runs-container');
+                if (!runs.length) {
+                    container.innerHTML = ui.renderEmptyState('実行履歴がありません', 'Runが生成されるとここに表示されます。');
+                    return;
+                }
+                container.innerHTML = runs.map(renderRun).join('');
+                setGlobalError(null);
+            } catch (err) {
+                const normalized = errors.normalizeError(err, err && err.response);
+                document.getElementById('runs-container').innerHTML = ui.renderErrorPanel(normalized);
+                setGlobalError(normalized);
+            }
         }
 
         function renderRun(run) {
-            const files = run.files || [];
+            const files = parsers.normalizeFiles(run.files).map(item => item.name);
             const fileBadges = REQUIRED_FILES.map(f => {
                 const exists = files.includes(f);
                 return `<span class="file-badge ${exists ? '' : 'file-missing'}">${f}</span>`;
@@ -177,20 +263,25 @@
 
             return `
                 <div class="run-card">
-                    <div class="run-header">
-                        <span class="run-id">${run.run_id}</span>
-                        <span class="run-date">${run.date}</span>
-                    </div>
-                    <div class="run-query">${run.query}</div>
-                    <div class="run-stats">
-                        <span class="stat">Papers: <span class="stat-value">${run.papers}</span></span>
-                        <span class="stat">Claims: <span class="stat-value">${run.claims}</span></span>
-                        <span class="stat">Evidence: <span class="stat-value">${run.evidence}</span></span>
-                    </div>
-                    <div class="bundle-files">${fileBadges}</div>
+                <div class="run-header">
+                    <span class="run-id">${run.run_id}</span>
+                    <span class="run-date">${run.timestamp || '-'}</span>
                 </div>
+                <div class="run-query">${run.query || run.input?.query || '-'}</div>
+                <div class="run-stats">
+                    <span class="stat">Papers: <span class="stat-value">${run.metrics?.paper_count || '-'}</span></span>
+                    <span class="stat">Claims: <span class="stat-value">${run.metrics?.claim_count || '-'}</span></span>
+                    <span class="stat">Evidence: <span class="stat-value">${run.metrics?.evidence_count || '-'}</span></span>
+                </div>
+                <div class="bundle-files">${fileBadges}</div>
+            </div>
             `;
         }
+
+        initSettings().then(() => {
+            refreshCapabilities();
+            loadRuns();
+        });
     </script>
 </body>
 


### PR DESCRIPTION
### Motivation
- Make all `dashboard/` pages tolerant to backend churn (missing endpoints, renamed endpoints, different response shapes) by centralizing API access.  
- Provide automatic three-step fallback for features: `API -> artifact file -> NOT_IMPLEMENTED` so pages never go white.  
- Allow recovery from authentication failures by storing API base and token in LocalStorage and exposing a Settings UI.  
- Surface distinct UI states for `NO_CONNECTION`, `UNAUTHORIZED`, `NOT_IMPLEMENTED`, `SERVER_ERROR` and other error kinds so operators can diagnose issues easily.

### Description
- Added a centralized adapter and supporting modules under `dashboard/assets/`: `app.js` (API adapter), `capabilities.js` (endpoint detection with TTL cache), `storage.js` (LocalStorage keys and accessors), `errors.js` (implementing `normalizeError`), `parsers.js` (JSONL/MD/files helpers), `fallbacks.js` (implementing `resolveWithFallback`), `ui.js` (status/error/toast/empty state renderers) and `styles.css` (shared state UI styles).  
- Replaced direct `fetch(...)` calls in pages with calls to the adapter API (e.g. `app.listRuns()`, `app.getRank()`, `app.uploadFiles()`), and added a `Settings` UI that persists `JAVIS_API_BASE` and `JAVIS_API_TOKEN` via `JarvisStorage`.  
- Implemented error normalization in `JarvisErrors.normalizeError` to classify errors into `NO_CONNECTION`, `TIMEOUT`, `UNAUTHORIZED`, `NOT_IMPLEMENTED`, `SERVER_ERROR`, and `BAD_RESPONSE` and return a consistent shape for the UI.  
- Implemented capability checks in `JarvisCapabilities.getCapabilities()` (with 5-minute TTL) and a shared `resolveWithFallback` flow used by ranking, claims, QA, export and other features to attempt API, then artifact file, then a not-implemented response.

### Testing
- Verified pages load via a lightweight local server using `python -m http.server` and captured a headless screenshot with Playwright which successfully loaded `index.html` (screenshot artifact produced).  
- Ran `rg` to confirm direct `fetch(...)` usage was removed from the HTML pages and that API calls are centralized in `assets/app.js` (check succeeded).  
- Manually exercised key flows in the instrumented pages (runs listing, research rank path, finance simulate/optimize) which routed through the adapter and produced UI error/pending/empty states (no uncaught exceptions observed).  
- Capability checks and LocalStorage settings were exercised via the Settings UI and the `getCapabilities(force=true)` path, and reported expected badges/errors (checks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695220ccb9648330a33c9896087da7e6)