### PR TITLE
Add API v1 contract, `/api/capabilities`, stable Runs API, and smoke tests

### DIFF
--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -33,7 +33,8 @@ except ImportError:
 
 
 # Constants
-RUNS_DIR = Path("logs/runs")
+RUNS_DIR = Path("data/runs")
+LEGACY_RUNS_DIR = Path("logs/runs")
 UPLOADS_DIR = Path("data/uploads")
 MAX_UPLOAD_SIZE = 100 * 1024 * 1024  # 100MB per file
 MAX_BATCH_FILES = 100
@@ -141,6 +142,133 @@ def get_file_hash(filepath: Path) -> str:
             sha256.update(chunk)
     return sha256.hexdigest()
 
+def normalize_status(status: str) -> str:
+    """Normalize status into contract-compatible value."""
+    normalized = status.lower().strip()
+    if normalized in {"queued", "running", "success", "failed"}:
+        return normalized
+    if normalized in {"error", "failure", "failed"}:
+        return "failed"
+    if normalized in {"complete", "completed", "success", "succeeded"}:
+        return "success"
+    if normalized in {"pending", "queued"}:
+        return "queued"
+    if normalized in {"in_progress", "progress"}:
+        return "running"
+    return "running"
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _load_jsonl(path: Path) -> list:
+    if not path.exists():
+        return []
+    rows = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    rows.append(json.loads(line))
+    except Exception:
+        return []
+    return rows
+
+
+def _iter_run_dirs() -> list[Path]:
+    RUNS_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = []
+    if LEGACY_RUNS_DIR.exists():
+        legacy = [d for d in LEGACY_RUNS_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")]
+    current = [d for d in RUNS_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")]
+    run_dirs = {d.name: d for d in legacy}
+    for run_dir in current:
+        run_dirs[run_dir.name] = run_dir
+    return list(run_dirs.values())
+
+
+def _resolve_run_dir(run_id: str) -> Path:
+    run_dir = RUNS_DIR / run_id
+    if run_dir.exists():
+        return run_dir
+    legacy = LEGACY_RUNS_DIR / run_id
+    if legacy.exists():
+        return legacy
+    raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+
+def _run_timestamps(run_dir: Path) -> tuple[str, str]:
+    stat = run_dir.stat()
+    created_at = datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc).isoformat()
+    updated_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+    return created_at, updated_at
+
+
+def _list_run_files(run_dir: Path) -> list[dict]:
+    files = []
+    for file_path in sorted(run_dir.rglob("*")):
+        if file_path.is_file():
+            rel_path = file_path.relative_to(run_dir).as_posix()
+            files.append(
+                {
+                    "path": rel_path,
+                    "size": file_path.stat().st_size,
+                    "sha256": get_file_hash(file_path),
+                }
+            )
+    return files
+
+
+def _build_run_response(run_dir: Path, include_files: bool) -> dict:
+    result = _load_json(run_dir / "result.json")
+    eval_summary = _load_json(run_dir / "eval_summary.json")
+    warnings = _load_jsonl(run_dir / "warnings.jsonl")
+    errors = _load_jsonl(run_dir / "errors.jsonl")
+    progress = _load_json(run_dir / "progress.json")
+    created_at, updated_at = _run_timestamps(run_dir)
+    files_list = _list_run_files(run_dir) if include_files else []
+
+    response = {
+        "run_id": run_dir.name,
+        "status": normalize_status(result.get("status", "running")),
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "progress": {
+            "step": progress.get("step", ""),
+            "percent": progress.get("percent", 0),
+            "counts": progress.get("counts", {}),
+        },
+        "metrics": eval_summary.get("metrics", {}),
+        "warnings": warnings,
+        "errors": errors,
+        "files": files_list,
+    }
+
+    files_map = {}
+    for entry in files_list:
+        files_map[entry["path"]] = {
+            "exists": True,
+            "size": entry["size"],
+            "sha256": entry["sha256"],
+        }
+    response["files_map"] = files_map
+
+    report_file = run_dir / "report.md"
+    if report_file.exists():
+        try:
+            with open(report_file, "r", encoding="utf-8") as f:
+                response["report"] = f.read()
+        except Exception:
+            response["report"] = ""
+    return response
+
 
 def load_run_summary(run_dir: Path) -> dict:
     """Load run summary from directory."""
@@ -197,47 +325,23 @@ if FASTAPI_AVAILABLE:
     @app.get("/api/runs")
     async def list_runs(limit: int = 20, _: bool = Depends(verify_token)):
         """List runs from logs/runs/ (per BUNDLE_CONTRACT.md)."""
-        RUNS_DIR.mkdir(parents=True, exist_ok=True)
-        
-        runs = []
-        run_dirs = [d for d in RUNS_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        run_dirs = _iter_run_dirs()
         run_dirs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-        
-        for run_dir in run_dirs[:limit]:
-            runs.append(load_run_summary(run_dir))
-        
+        runs = [_build_run_response(run_dir, include_files=False) for run_dir in run_dirs[:limit]]
         return {"runs": runs, "total": len(run_dirs)}
 
     @app.get("/api/runs/{run_id}")
     async def get_run(run_id: str, _: bool = Depends(verify_token)):
         """Get run details."""
-        run_dir = RUNS_DIR / run_id
-        
-        if not run_dir.exists():
-            raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-        
-        summary = load_run_summary(run_dir)
-        
-        # Add file list
-        files = {}
-        for f in run_dir.iterdir():
-            if f.is_file():
-                files[f.name] = {
-                    "exists": True,
-                    "size": f.stat().st_size,
-                }
-        summary["files"] = files
-        
-        # Load report.md if exists
-        report_file = run_dir / "report.md"
-        if report_file.exists():
-            try:
-                with open(report_file, "r", encoding="utf-8") as f:
-                    summary["report"] = f.read()
-            except:
-                summary["report"] = ""
-        
-        return summary
+        run_dir = _resolve_run_dir(run_id)
+        return _build_run_response(run_dir, include_files=True)
+
+    @app.get("/api/runs/{run_id}/files")
+    async def list_run_files(run_id: str, _: bool = Depends(verify_token)):
+        """List files for a run."""
+        run_dir = _resolve_run_dir(run_id)
+        files = _list_run_files(run_dir)
+        return {"files": files}
 
     @app.get("/api/runs/{run_id}/manifest")
     async def get_run_manifest(run_id: str, _: bool = Depends(verify_token)):
@@ -248,33 +352,98 @@ if FASTAPI_AVAILABLE:
         with open(manifest_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
-    @app.get("/api/runs/{run_id}/files/{filename}")
-    async def get_run_file(run_id: str, filename: str, _: bool = Depends(verify_token)):
+    @app.get("/api/runs/{run_id}/files/{path:path}")
+    async def get_run_file(run_id: str, path: str, _: bool = Depends(verify_token)):
         """Get specific file from run."""
-        run_dir = RUNS_DIR / run_id
-        filepath = run_dir / filename
-        
+        run_dir = _resolve_run_dir(run_id)
+        candidate = Path(path)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise HTTPException(status_code=400, detail="Invalid path")
+        filepath = (run_dir / candidate).resolve()
+        run_root = run_dir.resolve()
+        if not str(filepath).startswith(str(run_root)):
+            raise HTTPException(status_code=400, detail="Invalid path")
         if not filepath.exists():
-            raise HTTPException(status_code=404, detail=f"File {filename} not found")
-        
-        # Return JSON content directly for JSON files
-        if filename.endswith(".json"):
-            try:
-                with open(filepath, "r", encoding="utf-8") as f:
-                    return json.load(f)
-            except:
-                pass
-        
-        # Return JSONL as array
-        if filename.endswith(".jsonl"):
-            try:
-                with open(filepath, "r", encoding="utf-8") as f:
-                    return [json.loads(line) for line in f if line.strip()]
-            except:
-                pass
-        
-        # Return as file
-        return FileResponse(filepath)
+            raise HTTPException(status_code=404, detail=f"File {path} not found")
+        return FileResponse(
+            filepath,
+            filename=candidate.name,
+            media_type="application/octet-stream",
+        )
+
+    @app.get("/api/runs/{run_id}/events")
+    async def get_run_events(run_id: str, _: bool = Depends(verify_token)):
+        """Run events are not implemented."""
+        raise HTTPException(status_code=501, detail="Run events not implemented")
+
+    @app.get("/api/capabilities")
+    async def get_capabilities(_: bool = Depends(verify_token)):
+        """Report API capabilities."""
+        return {
+            "version": "v1",
+            "features": {
+                "runs": True,
+                "events": False,
+                "research_rank": True,
+                "research_paper": True,
+                "qa_report": False,
+                "submission": False,
+                "feedback": False,
+                "decision": False,
+                "finance": True,
+            },
+            "endpoints": {
+                "runs_list": "/api/runs",
+                "run_detail": "/api/runs/{run_id}",
+                "run_files": "/api/runs/{run_id}/files",
+                "run_file_get": "/api/runs/{run_id}/files/{path}",
+            },
+        }
+
+    @app.get("/api/qa/report")
+    async def qa_report(_: bool = Depends(verify_token)):
+        """QA report not yet implemented."""
+        raise HTTPException(status_code=501, detail="QA report not implemented")
+
+    @app.post("/api/submission/build")
+    async def build_submission(_: bool = Depends(verify_token)):
+        """Submission build not yet implemented."""
+        raise HTTPException(status_code=501, detail="Submission build not implemented")
+
+    @app.get("/api/submission/run/{run_id}/latest")
+    async def submission_latest(run_id: str, _: bool = Depends(verify_token)):
+        """Submission latest not yet implemented."""
+        raise HTTPException(status_code=501, detail="Submission latest not implemented")
+
+    @app.get("/api/submission/run/{run_id}/changelog")
+    async def submission_changelog(run_id: str, version: str, _: bool = Depends(verify_token)):
+        """Submission changelog not yet implemented."""
+        raise HTTPException(status_code=501, detail="Submission changelog not implemented")
+
+    @app.get("/api/submission/run/{run_id}/email")
+    async def submission_email(
+        run_id: str,
+        version: str,
+        recipient_type: str,
+        _: bool = Depends(verify_token),
+    ):
+        """Submission email not yet implemented."""
+        raise HTTPException(status_code=501, detail="Submission email not implemented")
+
+    @app.get("/api/feedback/risk")
+    async def feedback_risk(run_id: str, _: bool = Depends(verify_token)):
+        """Feedback risk not yet implemented."""
+        raise HTTPException(status_code=501, detail="Feedback risk not implemented")
+
+    @app.post("/api/feedback/import")
+    async def feedback_import(_: bool = Depends(verify_token)):
+        """Feedback import not yet implemented."""
+        raise HTTPException(status_code=501, detail="Feedback import not implemented")
+
+    @app.post("/api/decision/simulate")
+    async def decision_simulate(_: bool = Depends(verify_token)):
+        """Decision simulate not yet implemented."""
+        raise HTTPException(status_code=501, detail="Decision simulate not implemented")
 
     @app.post("/api/run", response_model=RunResponse)
     async def start_run(request: RunRequest, _: bool = Depends(verify_token)):
@@ -651,6 +820,16 @@ if FASTAPI_AVAILABLE:
     @app.get("/run/{run_id}")
     async def get_run_legacy(run_id: str, _: bool = Depends(verify_token)):
         """Legacy run endpoint."""
+        return await get_run(run_id, _)
+
+    @app.get("/api/run")
+    async def list_runs_api_legacy(limit: int = 20, _: bool = Depends(verify_token)):
+        """Legacy API runs endpoint."""
+        return await list_runs(limit, _)
+
+    @app.get("/api/run/{run_id}")
+    async def get_run_api_legacy(run_id: str, _: bool = Depends(verify_token)):
+        """Legacy API run endpoint."""
         return await get_run(run_id, _)
 
 

--- a/jarvis_web/contracts/api_contract_v1.yaml
+++ b/jarvis_web/contracts/api_contract_v1.yaml
@@ -1,0 +1,230 @@
+openapi: 3.0.3
+info:
+  title: JARVIS API Contract v1
+  version: v1
+servers:
+  - url: /
+paths:
+  /api/health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+  /api/capabilities:
+    get:
+      summary: Capabilities
+      responses:
+        '200':
+          description: OK
+  /api/runs:
+    get:
+      summary: List runs
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: OK
+  /api/runs/{run_id}:
+    get:
+      summary: Run detail
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+  /api/runs/{run_id}/files:
+    get:
+      summary: List run files
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /api/runs/{run_id}/files/{path}:
+    get:
+      summary: Download run file
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File
+        '400':
+          description: Invalid path
+        '404':
+          description: Not found
+  /api/runs/{run_id}/events:
+    get:
+      summary: Run events
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/research/rank:
+    get:
+      summary: Research rank
+      parameters:
+        - in: query
+          name: run_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: top_k
+          schema:
+            type: integer
+        - in: query
+          name: q
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+  /api/research/paper/{paper_id}:
+    get:
+      summary: Research paper
+      parameters:
+        - in: path
+          name: paper_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: run_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+  /api/qa/report:
+    get:
+      summary: QA report
+      parameters:
+        - in: query
+          name: run_id
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/submission/build:
+    post:
+      summary: Build submission
+      responses:
+        '501':
+          description: Not implemented
+  /api/submission/run/{run_id}/latest:
+    get:
+      summary: Submission latest
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/submission/run/{run_id}/changelog:
+    get:
+      summary: Submission changelog
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: version
+          required: true
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/submission/run/{run_id}/email:
+    get:
+      summary: Submission email
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: version
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: recipient_type
+          required: true
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/feedback/risk:
+    get:
+      summary: Feedback risk
+      parameters:
+        - in: query
+          name: run_id
+          schema:
+            type: string
+      responses:
+        '501':
+          description: Not implemented
+  /api/feedback/import:
+    post:
+      summary: Feedback import
+      responses:
+        '501':
+          description: Not implemented
+  /api/decision/simulate:
+    post:
+      summary: Decision simulate
+      responses:
+        '501':
+          description: Not implemented
+  /api/finance/optimize:
+    post:
+      summary: Finance optimize
+      responses:
+        '200':
+          description: OK
+        '500':
+          description: Error

--- a/tests/smoke_api_v1.py
+++ b/tests/smoke_api_v1.py
@@ -1,0 +1,85 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    fastapi = pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.testclient")
+
+    from fastapi.testclient import TestClient
+    from jarvis_web import app as app_module
+
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(app_module, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(app_module, "LEGACY_RUNS_DIR", legacy_dir)
+
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "result.json").write_text(json.dumps({"status": "success"}), encoding="utf-8")
+    (run_dir / "eval_summary.json").write_text(json.dumps({"metrics": {"kpi": 1}}), encoding="utf-8")
+    (run_dir / "progress.json").write_text(
+        json.dumps({"step": "done", "percent": 100, "counts": {"items": 1}}),
+        encoding="utf-8",
+    )
+    (run_dir / "warnings.jsonl").write_text(json.dumps({"warning": "none"}) + "\n", encoding="utf-8")
+    (run_dir / "errors.jsonl").write_text("", encoding="utf-8")
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    (artifacts_dir / "sample.txt").write_text("hello", encoding="utf-8")
+
+    return TestClient(app_module.app)
+
+
+def test_health(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+
+
+def test_capabilities(client):
+    response = client.get("/api/capabilities")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == "v1"
+    assert "features" in payload
+
+
+def test_runs_list(client):
+    response = client.get("/api/runs")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] >= 1
+    assert payload["runs"][0]["run_id"] == "run-123"
+
+
+def test_run_detail_and_files(client):
+    response = client.get("/api/runs/run-123")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert any(entry["path"] == "artifacts/sample.txt" for entry in payload["files"])
+
+    list_response = client.get("/api/runs/run-123/files")
+    assert list_response.status_code == 200
+    files_payload = list_response.json()
+    assert any(entry["path"] == "artifacts/sample.txt" for entry in files_payload["files"])
+
+    download = client.get("/api/runs/run-123/files/artifacts/sample.txt")
+    assert download.status_code == 200
+
+
+def test_unimplemented_endpoints(client):
+    response = client.get("/api/qa/report")
+    assert response.status_code == 501
+    response = client.post("/api/submission/build")
+    assert response.status_code == 501
+    response = client.get("/api/feedback/risk")
+    assert response.status_code == 501
+    response = client.post("/api/decision/simulate")
+    assert response.status_code == 501


### PR DESCRIPTION
### Motivation
- Stabilize the read-side API surface used by frontends by formalizing an API v1 contract and a stable Runs schema.
- Let the server declare feature availability and canonical endpoints via a `GET /api/capabilities` endpoint so the UI does not have to guess.
- Ensure safe, auditable delivery of produced artifacts by centralizing run storage and adding path traversal protection for file downloads.
- Smooth endpoint churn by providing legacy alias endpoints that map to the v1 surface.

### Description
- Standardized runs storage to `data/runs` (keeps `logs/runs` as `LEGACY_RUNS_DIR`) and added helpers including `normalize_status`, `_build_run_response`, `_list_run_files`, and `_resolve_run_dir` to produce a contract-compatible run JSON for `GET /api/runs` and `GET /api/runs/{run_id}`.
- Implemented safe file APIs `GET /api/runs/{run_id}/files` and `GET /api/runs/{run_id}/files/{path}` with realpath checks and `FileResponse` download behavior, plus `GET /api/runs/{run_id}/events` returning `501` for unimplemented events.
- Added `GET /api/capabilities` that returns a `v1` feature map and endpoint hints, plus 501 stubs for unimplemented services (`/api/qa/report`, `/api/submission/*`, `/api/feedback/*`, `/api/decision/*`) and legacy alias endpoints `/api/run` and `/api/run/{run_id}`.
- Added the API contract file `jarvis_web/contracts/api_contract_v1.yaml` (OpenAPI) and a pytest smoke suite `tests/smoke_api_v1.py` that exercises health, capabilities, runs listing/detail, file listing/download, and expected `501` responses.

### Testing
- Added `tests/smoke_api_v1.py`, a pytest smoke test that uses FastAPI `TestClient` and temporary run directories to validate `GET /api/health`, `GET /api/capabilities`, `GET /api/runs`, `GET /api/runs/{run_id}`, file listing/download, and `501` behavior for unimplemented endpoints.
- The smoke tests were added to the repository but were not executed as part of this rollout (no CI/test run was performed).
- The smoke test is self-contained and uses monkeypatched `RUNS_DIR`/`LEGACY_RUNS_DIR` so it can run in CI or locally without modifying real data.
- No automated test failures are reported because the tests were not run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695223296678833095894fb879cd7fbd)