### PR TITLE
Add KB ingestion, topic merging, and weekly pack generation with API and dashboard

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -132,6 +132,12 @@ const app = (() => {
   const getFeedbackRisk = (runId) => apiFetch(`/api/feedback/risk?run_id=${encodeURIComponent(runId)}`);
   const decisionSimulate = (payload) => apiFetch("/api/decision/simulate", { method: "POST", body: payload });
   const financeOptimize = (payload) => apiFetch("/api/finance/optimize", { method: "POST", body: payload });
+  const getKbStatus = () => apiFetch("/api/kb/status");
+  const getKbTopic = (topic) => apiFetch(`/api/kb/topic/${encodeURIComponent(topic)}`);
+  const getKbPaper = (pmid) => apiFetch(`/api/kb/paper/${encodeURIComponent(pmid)}`);
+  const listPacks = () => apiFetch("/api/packs");
+  const generatePack = () => apiFetch("/api/packs/generate", { method: "POST" });
+  const buildPackDownloadUrl = (packId) => buildUrl(`/api/packs/${encodeURIComponent(packId)}/download`);
 
   return {
     STORAGE_BASE,
@@ -161,6 +167,12 @@ const app = (() => {
     getFeedbackRisk,
     decisionSimulate,
     financeOptimize,
+    getKbStatus,
+    getKbTopic,
+    getKbPaper,
+    listPacks,
+    generatePack,
+    buildPackDownloadUrl,
     buildUrl,
   };
 })();

--- a/dashboard/decision.html
+++ b/dashboard/decision.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/feedback.html
+++ b/dashboard/feedback.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/kb.html
+++ b/dashboard/kb.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Base Dashboard</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body data-page="kb">
+  <nav class="top-nav">
+    <a href="index.html">Home</a>
+    <a href="runs.html">Runs</a>
+    <a href="schedule.html">Schedule</a>
+    <a href="feedback.html">Feedback Risk</a>
+    <a href="decision.html">Decision</a>
+    <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
+    <a href="settings.html">Settings</a>
+  </nav>
+  <main class="container">
+    <header class="page-header">
+      <h1>Knowledge Base</h1>
+      <p>KBの状態確認、Topicノートのプレビュー、学習パックのダウンロード。</p>
+    </header>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>KB Status</h2>
+        <button class="secondary" id="refresh-kb">更新</button>
+      </div>
+      <div class="grid cols-3">
+        <div class="kpi-card">
+          <h3>Papers</h3>
+          <div class="value" id="kb-papers">-</div>
+        </div>
+        <div class="kpi-card">
+          <h3>Topics</h3>
+          <div class="value" id="kb-topics">-</div>
+        </div>
+        <div class="kpi-card">
+          <h3>Last Updated</h3>
+          <div class="value" id="kb-updated">-</div>
+        </div>
+      </div>
+      <div id="kb-topic-list" class="tag-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Topic Preview</h2>
+      </div>
+      <div class="grid cols-2">
+        <div>
+          <label class="muted">Topic</label>
+          <select id="topic-select"></select>
+          <button class="secondary" id="preview-topic">プレビュー</button>
+        </div>
+        <pre id="topic-preview" class="code-block">未選択</pre>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Weekly Packs</h2>
+        <button class="secondary" id="generate-pack">Generate pack now</button>
+      </div>
+      <table class="table" id="pack-table">
+        <thead>
+          <tr>
+            <th>Pack ID</th>
+            <th>Generated At</th>
+            <th>Notes</th>
+            <th>Download</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="pack-empty" class="notice">パックがありません。</div>
+    </section>
+  </main>
+
+  <script src="assets/app.js"></script>
+  <script src="assets/ui.js"></script>
+  <script>
+    const setActiveNav = () => {
+      ui.qsa(".top-nav a").forEach((link) => {
+        if (link.getAttribute("href").includes("kb")) {
+          link.classList.add("active");
+        }
+      });
+    };
+
+    const renderStatus = async () => {
+      const response = await app.apiFetchSafe("/api/kb/status");
+      if (!response.ok) {
+        ui.qs("#kb-papers").textContent = "-";
+        ui.qs("#kb-topics").textContent = "-";
+        ui.qs("#kb-updated").textContent = "未接続";
+        ui.qs("#kb-topic-list").textContent = "";
+        return;
+      }
+      const data = response.data || {};
+      ui.qs("#kb-papers").textContent = data.papers ?? 0;
+      ui.qs("#kb-topics").textContent = data.topics ?? 0;
+      ui.qs("#kb-updated").textContent = ui.formatDateTime(data.last_updated);
+
+      const topicList = ui.qs("#kb-topic-list");
+      topicList.innerHTML = "";
+      const topics = data.topic_list || [];
+      topics.forEach((topic) => {
+        topicList.appendChild(ui.el("span", { className: "badge", text: topic }));
+      });
+
+      const select = ui.qs("#topic-select");
+      select.innerHTML = "";
+      topics.forEach((topic) => {
+        select.appendChild(ui.el("option", { text: topic, attrs: { value: topic } }));
+      });
+    };
+
+    const previewTopic = async () => {
+      const select = ui.qs("#topic-select");
+      const topic = select.value;
+      if (!topic) {
+        ui.qs("#topic-preview").textContent = "未選択";
+        return;
+      }
+      const response = await app.apiFetchSafe(`/api/kb/topic/${encodeURIComponent(topic)}`);
+      if (!response.ok) {
+        ui.qs("#topic-preview").textContent = "取得失敗";
+        return;
+      }
+      ui.qs("#topic-preview").textContent = response.data.content || "";
+    };
+
+    const renderPacks = async () => {
+      const tableBody = ui.qs("#pack-table tbody");
+      tableBody.innerHTML = "";
+      const empty = ui.qs("#pack-empty");
+      const response = await app.apiFetchSafe("/api/packs");
+      if (!response.ok) {
+        empty.textContent = "未接続";
+        empty.style.display = "block";
+        return;
+      }
+      const packs = response.data.packs || [];
+      if (!packs.length) {
+        empty.style.display = "block";
+        return;
+      }
+      empty.style.display = "none";
+      packs.forEach((pack) => {
+        const meta = pack.metadata || {};
+        const row = ui.el("tr");
+        row.appendChild(ui.el("td", { text: pack.id }));
+        row.appendChild(ui.el("td", { text: ui.formatDateTime(meta.generated_at) }));
+        row.appendChild(ui.el("td", { text: (meta.notes || []).length }));
+        const downloadUrl = app.buildPackDownloadUrl(pack.id);
+        const link = downloadUrl ? `<a href="${downloadUrl}">Download</a>` : "-";
+        row.appendChild(ui.el("td", { html: link }));
+        tableBody.appendChild(row);
+      });
+    };
+
+    const generatePack = async () => {
+      const response = await app.apiFetchSafe("/api/packs/generate", { method: "POST" });
+      if (!response.ok) {
+        alert("パック生成に失敗しました。");
+        return;
+      }
+      await renderPacks();
+    };
+
+    const init = () => {
+      setActiveNav();
+      renderStatus();
+      renderPacks();
+      ui.qs("#refresh-kb").addEventListener("click", renderStatus);
+      ui.qs("#preview-topic").addEventListener("click", previewTopic);
+      ui.qs("#generate-pack").addEventListener("click", generatePack);
+    };
+
+    init();
+  </script>
+</body>
+</html>

--- a/dashboard/run.html
+++ b/dashboard/run.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/schedule.html
+++ b/dashboard/schedule.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -14,6 +14,7 @@
     <a href="feedback.html">Feedback Risk</a>
     <a href="decision.html">Decision</a>
     <a href="finance.html">Finance</a>
+    <a href="kb.html">Knowledge Base</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/jarvis_core/kb/__init__.py
+++ b/jarvis_core/kb/__init__.py
@@ -1,0 +1,6 @@
+"""Knowledge base utilities for Obsidian-compatible notes."""
+
+from .indexer import ingest_run
+from .weekly_pack import generate_weekly_pack
+
+__all__ = ["ingest_run", "generate_weekly_pack"]

--- a/jarvis_core/kb/citations.py
+++ b/jarvis_core/kb/citations.py
@@ -1,0 +1,25 @@
+"""Citation formatting helpers."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def format_evidence_items(evidence: Iterable[Mapping]) -> str:
+    lines = []
+    for item in evidence:
+        locator = item.get("locator") or item.get("section") or ""
+        chunk_id = item.get("chunk_id") or item.get("chunkId") or ""
+        quote = item.get("quote") or item.get("snippet") or ""
+        quote = quote.replace("\n", " ").strip()
+        if quote:
+            quote = f'"{quote}"'
+        parts = []
+        if locator:
+            parts.append(f"Section: {locator}")
+        if chunk_id:
+            parts.append(f"chunk_id={chunk_id}")
+        if quote:
+            parts.append(f"文章抜粋: {quote}")
+        if parts:
+            lines.append(" / ".join(parts))
+    return "; ".join(lines) if lines else "根拠情報なし"

--- a/jarvis_core/kb/dedup.py
+++ b/jarvis_core/kb/dedup.py
@@ -1,0 +1,16 @@
+"""Deduplicate KB content."""
+from __future__ import annotations
+
+from typing import Iterable, List, Mapping
+
+
+def dedup_claims(claims: Iterable[Mapping]) -> List[Mapping]:
+    seen = set()
+    unique = []
+    for claim in claims:
+        key = (claim.get("claim_id") or "", claim.get("claim_text") or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(claim)
+    return unique

--- a/jarvis_core/kb/indexer.py
+++ b/jarvis_core/kb/indexer.py
@@ -1,0 +1,303 @@
+"""Run artifact -> knowledge base ingestion."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from .citations import format_evidence_items
+from .dedup import dedup_claims
+from .merger import merge_sections
+from .normalizer import TermNormalizer
+from .quality_tags import assign_quality_tags
+from .schema import format_front_matter, parse_front_matter
+from .topic_router import TopicRouter
+
+
+AUTO_CLAIMS_START = "<!-- AUTO-CLAIMS-START -->"
+AUTO_CLAIMS_END = "<!-- AUTO-CLAIMS-END -->"
+AUTO_TOPIC_START = "<!-- AUTO-TOPIC-START -->"
+AUTO_TOPIC_END = "<!-- AUTO-TOPIC-END -->"
+AUTO_EVIDENCE_START = "<!-- AUTO-EVIDENCE-START -->"
+AUTO_EVIDENCE_END = "<!-- AUTO-EVIDENCE-END -->"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _load_jsonl(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    rows: List[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def _gather_claims(run_dir: Path) -> List[dict]:
+    claims: List[dict] = []
+    direct = run_dir / "claims.jsonl"
+    if direct.exists():
+        claims.extend(_load_jsonl(direct))
+    claims_dir = run_dir / "claims"
+    if claims_dir.exists():
+        for path in sorted(claims_dir.glob("*.jsonl")):
+            claims.extend(_load_jsonl(path))
+    return claims
+
+
+def _gather_papers(run_dir: Path) -> List[dict]:
+    rank_path = run_dir / "research_rank.json"
+    if rank_path.exists():
+        data = _load_json(rank_path)
+        if isinstance(data, dict):
+            return data.get("papers") or data.get("results") or []
+    for name in ["canonical_papers.jsonl", "papers.jsonl"]:
+        path = run_dir / name
+        if path.exists():
+            return _load_jsonl(path)
+    return []
+
+
+def _normalize_pmid(paper: Mapping) -> str:
+    pmid = paper.get("pmid") or paper.get("PMID") or ""
+    if pmid:
+        return str(pmid)
+    paper_id = paper.get("paper_id") or paper.get("paperId") or ""
+    if isinstance(paper_id, str) and paper_id.lower().startswith("pmid:"):
+        return paper_id.split(":", 1)[1]
+    return str(paper_id) if paper_id else "unknown"
+
+
+def _paper_tags(paper: Mapping) -> List[str]:
+    tags = paper.get("tags") or paper.get("keywords") or []
+    if isinstance(tags, str):
+        tags = [item.strip() for item in tags.split(",") if item.strip()]
+    return [str(tag) for tag in tags]
+
+
+def _build_claim_markdown(claims: Iterable[Mapping]) -> str:
+    blocks = []
+    for idx, claim in enumerate(claims, start=1):
+        quality = assign_quality_tags(claim)
+        evidence_text = format_evidence_items(claim.get("evidence") or [])
+        note = quality.get("note") or ""
+        note_line = f"- 注記: {note}" if note else "- 注記: "
+        blocks.append(
+            "\n".join(
+                [
+                    f"## Claim {idx}",
+                    f"- 主張: {claim.get('claim_text') or claim.get('claim') or ''}",
+                    f"- 根拠: {evidence_text}",
+                    f"- 確度: {quality.get('evidence_strength')}",
+                    note_line,
+                ]
+            )
+        )
+    return "\n\n".join(blocks) if blocks else "- 重要claimは未抽出"
+
+
+def _ensure_kb_dirs(kb_root: Path) -> None:
+    (kb_root / "notes" / "papers").mkdir(parents=True, exist_ok=True)
+    (kb_root / "notes" / "topics").mkdir(parents=True, exist_ok=True)
+    (kb_root / "notes" / "runs").mkdir(parents=True, exist_ok=True)
+    (kb_root / "dict").mkdir(parents=True, exist_ok=True)
+
+
+def _render_paper_note(front: dict, body: str) -> str:
+    return f"{format_front_matter(front)}\n\n{body.strip()}\n"
+
+
+def _base_paper_body(summary: str) -> str:
+    return (
+        "# 要約（300〜500字）\n"
+        f"{summary}\n\n"
+        "# 重要claim（根拠付き）\n"
+        f"{AUTO_CLAIMS_START}\n"
+        "- 重要claimは未抽出\n"
+        f"{AUTO_CLAIMS_END}\n\n"
+        "# 自分の研究への接続\n"
+        "- 使いどころ:\n"
+        "- 次に読むべき:\n"
+    )
+
+
+def _base_topic_body(topic: str) -> str:
+    return (
+        f"# {topic}：今週の更新\n"
+        f"{AUTO_TOPIC_START}\n"
+        "- 新規の高確度ポイント（S/A Tier）\n"
+        "- 争点（論文間で矛盾）\n"
+        "- 未確定（追加調査が必要）\n"
+        f"{AUTO_TOPIC_END}\n\n"
+        "# エビデンス・マップ\n"
+        f"{AUTO_EVIDENCE_START}\n"
+        "- Claim → supporting papers（PMIDリンク）\n"
+        f"{AUTO_EVIDENCE_END}\n"
+    )
+
+
+def ingest_run(run_dir: Path, kb_root: Path = Path("data/kb"), run_id: Optional[str] = None) -> dict:
+    """Ingest run artifacts into KB."""
+    run_id = run_id or run_dir.name
+    _ensure_kb_dirs(kb_root)
+
+    normalizer = TermNormalizer(kb_root / "dict" / "synonyms.json")
+    router = TopicRouter(normalizer)
+
+    papers = _gather_papers(run_dir)
+    claims = _gather_claims(run_dir)
+    claims = dedup_claims(claims)
+
+    claims_by_paper: Dict[str, List[dict]] = {}
+    for claim in claims:
+        paper_id = claim.get("paper_id") or claim.get("paperId") or claim.get("pmid") or ""
+        if not paper_id:
+            continue
+        claims_by_paper.setdefault(str(paper_id), []).append(claim)
+
+    index_path = kb_root / "index.json"
+    index = _load_json(index_path)
+    index.setdefault("papers", {})
+    index.setdefault("topics", {})
+    index.setdefault("runs", {})
+
+    updated_papers = []
+    updated_topics = set()
+
+    for paper in papers:
+        pmid = _normalize_pmid(paper)
+        paper_id = paper.get("paper_id") or paper.get("paperId") or f"PMID:{pmid}"
+        title = paper.get("title") or ""
+        abstract = paper.get("abstract") or paper.get("summary") or ""
+        summary = abstract or "要約は未生成"
+        tags = _paper_tags(paper)
+        topics = router.classify([title, abstract], tags)
+
+        claim_list = claims_by_paper.get(str(paper_id), []) or claims_by_paper.get(f"PMID:{pmid}", [])
+        claim_markdown = _build_claim_markdown(claim_list)
+
+        paper_note_path = kb_root / "notes" / "papers" / f"PMID_{pmid}.md"
+        front_matter = {
+            "type": "paper",
+            "pmid": pmid,
+            "doi": paper.get("doi", ""),
+            "title": title,
+            "year": paper.get("year"),
+            "journal": paper.get("journal", ""),
+            "oa": paper.get("oa", paper.get("open_access", "unknown")),
+            "tier": paper.get("tier", "C"),
+            "score": paper.get("score", 0.0),
+            "run_id": run_id,
+            "tags": topics or tags,
+            "updated_at": _now(),
+        }
+
+        if paper_note_path.exists():
+            existing = paper_note_path.read_text(encoding="utf-8")
+            existing_front, body = parse_front_matter(existing)
+            merged_front = {**existing_front, **front_matter}
+            body = merge_sections(
+                body,
+                {
+                    "claims": (AUTO_CLAIMS_START, AUTO_CLAIMS_END, claim_markdown),
+                },
+            )
+            note_text = _render_paper_note(merged_front, body)
+        else:
+            body = _base_paper_body(summary)
+            body = merge_sections(
+                body,
+                {
+                    "claims": (AUTO_CLAIMS_START, AUTO_CLAIMS_END, claim_markdown),
+                },
+            )
+            note_text = _render_paper_note(front_matter, body)
+
+        paper_note_path.write_text(note_text, encoding="utf-8")
+        updated_papers.append(pmid)
+
+        index["papers"][pmid] = {
+            "pmid": pmid,
+            "topics": topics,
+            "path": str(paper_note_path.relative_to(kb_root)),
+            "updated_at": front_matter["updated_at"],
+            "run_id": run_id,
+            "tier": front_matter["tier"],
+        }
+        updated_topics.update(topics)
+
+    topic_updates: Dict[str, dict] = {}
+    for topic in updated_topics:
+        topic_note_path = kb_root / "notes" / "topics" / f"{topic}.md"
+        summary_lines = [
+            "- 新規の高確度ポイント（S/A Tier）",
+            "- 争点（論文間で矛盾）",
+            "- 未確定（追加調査が必要）",
+        ]
+        evidence_lines = []
+        for pmid in updated_papers:
+            evidence_lines.append(f"- {topic} のClaim → PMID_{pmid}")
+
+        body_sections = {
+            "topic": (AUTO_TOPIC_START, AUTO_TOPIC_END, "\n".join(summary_lines)),
+            "evidence": (AUTO_EVIDENCE_START, AUTO_EVIDENCE_END, "\n".join(evidence_lines) if evidence_lines else "- Claim → supporting papers（PMIDリンク）"),
+        }
+
+        if topic_note_path.exists():
+            existing = topic_note_path.read_text(encoding="utf-8")
+            existing_front, body = parse_front_matter(existing)
+            merged_front = {**existing_front, "type": "topic", "topic": topic, "updated_at": _now()}
+            body = merge_sections(body, body_sections)
+            note_text = f"{format_front_matter(merged_front)}\n\n{body.strip()}\n"
+        else:
+            front = {"type": "topic", "topic": topic, "updated_at": _now()}
+            body = _base_topic_body(topic)
+            body = merge_sections(body, body_sections)
+            note_text = f"{format_front_matter(front)}\n\n{body.strip()}\n"
+
+        topic_note_path.write_text(note_text, encoding="utf-8")
+        index["topics"][topic] = {
+            "topic": topic,
+            "path": str(topic_note_path.relative_to(kb_root)),
+            "updated_at": _now(),
+        }
+        topic_updates[topic] = index["topics"][topic]
+
+    run_note_path = kb_root / "notes" / "runs" / f"RUN_{run_id}_summary.md"
+    run_body = (
+        f"# Run {run_id} summary\n\n"
+        f"- Papers updated: {len(updated_papers)}\n"
+        f"- Topics updated: {len(updated_topics)}\n"
+    )
+    run_note_path.write_text(run_body, encoding="utf-8")
+
+    index["runs"][run_id] = {
+        "run_id": run_id,
+        "papers": updated_papers,
+        "topics": sorted(updated_topics),
+        "updated_at": _now(),
+        "path": str(run_note_path.relative_to(kb_root)),
+    }
+
+    index_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    return {
+        "papers": updated_papers,
+        "topics": sorted(updated_topics),
+        "run_id": run_id,
+    }

--- a/jarvis_core/kb/merger.py
+++ b/jarvis_core/kb/merger.py
@@ -1,0 +1,27 @@
+"""Merge updates into existing notes while preserving manual edits."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def _replace_between(text: str, start: str, end: str, replacement: str) -> str:
+    if start in text and end in text:
+        before, rest = text.split(start, 1)
+        _, after = rest.split(end, 1)
+        return f"{before}{start}\n{replacement}\n{end}{after}"
+    return ""
+
+
+def merge_sections(existing: str, sections: Dict[str, Tuple[str, str, str]]) -> str:
+    """Merge multiple sections.
+
+    sections: name -> (start_marker, end_marker, new_content)
+    """
+    updated = existing
+    for _, (start, end, content) in sections.items():
+        replaced = _replace_between(updated, start, end, content)
+        if replaced:
+            updated = replaced
+        else:
+            updated = f"{updated.rstrip()}\n\n{start}\n{content}\n{end}\n"
+    return updated

--- a/jarvis_core/kb/normalizer.py
+++ b/jarvis_core/kb/normalizer.py
@@ -1,0 +1,74 @@
+"""Normalize terms using synonym dictionary."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable
+
+DEFAULT_SYNONYMS = {
+    "cd73": ["nt5e", "ecto-5'-nucleotidase", "ecto5n"],
+    "adenosine": ["purinergic signaling", "adenosine pathway"],
+    "tme": ["tumor microenvironment", "tumour microenvironment"],
+}
+
+GREEK_MAP = {
+    "α": "alpha",
+    "β": "beta",
+    "γ": "gamma",
+    "δ": "delta",
+    "ε": "epsilon",
+    "κ": "kappa",
+}
+
+
+class TermNormalizer:
+    """Normalize terms using a synonym dictionary."""
+
+    def __init__(self, synonym_path: Path):
+        self.synonym_path = synonym_path
+        self.synonyms = self._load_synonyms(synonym_path)
+
+    def _load_synonyms(self, path: Path) -> Dict[str, list[str]]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(DEFAULT_SYNONYMS, f, ensure_ascii=False, indent=2)
+            return {key.lower(): [item.lower() for item in values] for key, values in DEFAULT_SYNONYMS.items()}
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            data = {}
+        normalized: Dict[str, list[str]] = {}
+        for key, values in data.items():
+            normalized[key.lower()] = [str(item).lower() for item in values]
+        return normalized
+
+    def normalize_text(self, text: str) -> str:
+        cleaned = text.lower()
+        for greek, latin in GREEK_MAP.items():
+            cleaned = cleaned.replace(greek, latin)
+        cleaned = re.sub(r"[-_/]", " ", cleaned)
+        cleaned = re.sub(r"[^a-z0-9\s]", " ", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned
+
+    def normalize_term(self, term: str) -> str:
+        cleaned = self.normalize_text(term)
+        if cleaned in self.synonyms:
+            return cleaned
+        for canonical, synonyms in self.synonyms.items():
+            if cleaned == canonical:
+                return canonical
+            if cleaned in synonyms:
+                return canonical
+        return cleaned
+
+    def expand_terms(self, terms: Iterable[str]) -> list[str]:
+        expanded = []
+        for term in terms:
+            normalized = self.normalize_term(term)
+            if normalized:
+                expanded.append(normalized)
+        return sorted(set(expanded))

--- a/jarvis_core/kb/quality_tags.py
+++ b/jarvis_core/kb/quality_tags.py
@@ -1,0 +1,38 @@
+"""Assign heuristic quality tags to claims."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def assign_quality_tags(claim: Mapping) -> dict:
+    evidence = claim.get("evidence") or []
+    evidence_count = len(evidence)
+    max_score = 0.0
+    for item in evidence:
+        try:
+            max_score = max(max_score, float(item.get("score", 0.0)))
+        except (TypeError, ValueError):
+            continue
+
+    if evidence_count >= 2 or max_score >= 0.7:
+        strength = "high"
+    elif evidence_count == 1 or max_score >= 0.4:
+        strength = "med"
+    else:
+        strength = "low"
+
+    tier = "C"
+    if strength == "high":
+        tier = "A"
+    elif strength == "med":
+        tier = "B"
+
+    needs_followup = strength == "low"
+
+    return {
+        "evidence_strength": strength,
+        "tier": tier,
+        "conflict": False,
+        "needs_followup": needs_followup,
+        "note": "（推測です）" if needs_followup else "",
+    }

--- a/jarvis_core/kb/schema.py
+++ b/jarvis_core/kb/schema.py
@@ -1,0 +1,115 @@
+"""Schema helpers for the knowledge base."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class EvidenceRef:
+    chunk_id: str
+    locator: str
+    quote: str
+    score: float = 0.0
+
+
+@dataclass
+class ClaimEntry:
+    claim_id: str
+    text: str
+    evidence: List[EvidenceRef] = field(default_factory=list)
+    evidence_strength: str = "low"
+    tier: str = "C"
+    conflict: bool = False
+    needs_followup: bool = False
+    note: Optional[str] = None
+
+
+@dataclass
+class PaperMeta:
+    pmid: str
+    title: str
+    doi: str = ""
+    year: Optional[int] = None
+    journal: str = ""
+    oa: str = "unknown"
+    tier: str = "C"
+    score: float = 0.0
+    run_id: str = ""
+    tags: List[str] = field(default_factory=list)
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass
+class TopicMeta:
+    topic: str
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass
+class RunSummary:
+    run_id: str
+    papers: List[str] = field(default_factory=list)
+    topics: List[str] = field(default_factory=list)
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+def format_front_matter(data: Dict[str, Any]) -> str:
+    """Create a minimal YAML front matter string."""
+    def render_value(value: Any) -> str:
+        if isinstance(value, list):
+            rendered = [render_value(item) for item in value]
+            return f"[{', '.join(rendered)}]"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if value is None:
+            return "null"
+        if isinstance(value, (int, float)):
+            return str(value)
+        text = str(value)
+        escaped = text.replace('"', '\\"')
+        return f"\"{escaped}\""
+
+    lines = ["---"]
+    for key, value in data.items():
+        lines.append(f"{key}: {render_value(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def parse_front_matter(text: str) -> tuple[Dict[str, Any], str]:
+    """Parse YAML-ish front matter and return (data, body)."""
+    if not text.startswith("---"):
+        return {}, text
+    parts = text.split("\n")
+    end_idx = None
+    for idx in range(1, len(parts)):
+        if parts[idx].strip() == "---":
+            end_idx = idx
+            break
+    if end_idx is None:
+        return {}, text
+    fm_lines = parts[1:end_idx]
+    body = "\n".join(parts[end_idx + 1 :]).lstrip("\n")
+    data: Dict[str, Any] = {}
+    for line in fm_lines:
+        if not line.strip() or ":" not in line:
+            continue
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if raw_value.startswith("[") and raw_value.endswith("]"):
+            inner = raw_value[1:-1].strip()
+            if not inner:
+                data[key] = []
+            else:
+                items = [item.strip().strip('"') for item in inner.split(",")]
+                data[key] = items
+        elif raw_value.lower() in {"true", "false"}:
+            data[key] = raw_value.lower() == "true"
+        elif raw_value.lower() == "null":
+            data[key] = None
+        else:
+            data[key] = raw_value.strip('"')
+    return data, body

--- a/jarvis_core/kb/topic_router.py
+++ b/jarvis_core/kb/topic_router.py
@@ -1,0 +1,37 @@
+"""Route papers into conceptual topics."""
+from __future__ import annotations
+
+from typing import Iterable, List, Set
+
+from .normalizer import TermNormalizer
+
+
+class TopicRouter:
+    """Rule-based topic classifier."""
+
+    def __init__(self, normalizer: TermNormalizer):
+        self.normalizer = normalizer
+
+    def _match_topics(self, text: str) -> Set[str]:
+        normalized_text = self.normalizer.normalize_text(text)
+        matches: Set[str] = set()
+        for canonical, synonyms in self.normalizer.synonyms.items():
+            if canonical and canonical in normalized_text:
+                matches.add(canonical)
+                continue
+            for synonym in synonyms:
+                if synonym and synonym in normalized_text:
+                    matches.add(canonical)
+                    break
+        return matches
+
+    def classify(self, text_blocks: Iterable[str], tags: Iterable[str]) -> List[str]:
+        matched: Set[str] = set()
+        for tag in tags:
+            normalized = self.normalizer.normalize_term(tag)
+            if normalized:
+                matched.add(normalized)
+        for block in text_blocks:
+            if block:
+                matched.update(self._match_topics(block))
+        return sorted(matched)

--- a/jarvis_core/kb/weekly_pack.py
+++ b/jarvis_core/kb/weekly_pack.py
@@ -1,0 +1,147 @@
+"""Weekly learning pack generation."""
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .schema import parse_front_matter
+
+
+@dataclass
+class PackFile:
+    path: Path
+    arcname: str
+
+
+def _iso_week_label(dt: datetime) -> str:
+    year, week, _ = dt.isocalendar()
+    return f"{year}-{week:02d}"
+
+
+def _load_index(kb_root: Path) -> dict:
+    index_path = kb_root / "index.json"
+    if not index_path.exists():
+        return {}
+    try:
+        with open(index_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _note_updated_within(path: Path, start: datetime, end: datetime) -> bool:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    front, _ = parse_front_matter(content)
+    updated_at = front.get("updated_at")
+    if updated_at:
+        try:
+            updated = datetime.fromisoformat(updated_at)
+        except ValueError:
+            updated = None
+    else:
+        updated = None
+    if updated is None:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        updated = mtime
+    if updated.tzinfo is None:
+        updated = updated.replace(tzinfo=timezone.utc)
+    return start <= updated <= end
+
+
+def _collect_week_notes(kb_root: Path, start: datetime, end: datetime, topics: Optional[Iterable[str]] = None) -> List[PackFile]:
+    notes: List[PackFile] = []
+    papers_dir = kb_root / "notes" / "papers"
+    topics_dir = kb_root / "notes" / "topics"
+
+    if papers_dir.exists():
+        for path in papers_dir.glob("*.md"):
+            if _note_updated_within(path, start, end):
+                notes.append(PackFile(path=path, arcname=f"notes/papers/{path.name}"))
+
+    if topics_dir.exists():
+        selected_topics = {t.lower() for t in topics} if topics else None
+        for path in topics_dir.glob("*.md"):
+            if selected_topics and path.stem.lower() not in selected_topics:
+                continue
+            notes.append(PackFile(path=path, arcname=f"notes/topics/{path.name}"))
+    return notes
+
+
+def _build_readme(week_label: str, notes: List[PackFile]) -> str:
+    note_list = "\n".join(f"- {file.arcname}" for file in notes) or "- 対象ノートなし"
+    return """# Weekly Learning Pack ({week_label})
+
+## 今週のトップ3論点
+- 主要論点1（要更新）
+- 主要論点2（要更新）
+- 主要論点3（要更新）
+
+## 次週の宿題（読むべき論文）
+- TODO: 次に読むべき論文を追加
+
+## 矛盾点一覧
+- TODO: 矛盾する主張を整理
+
+## 収録ノート
+{note_list}
+
+## Podcast化の指示
+- このパック全体を教材として、10分のポッドキャスト概要を作成する
+- 新規知見と未確定事項を明確に分けて話す
+- エビデンスへの参照（PMID/Claim）を明示する
+""".format(week_label=week_label, note_list=note_list)
+
+
+def _build_notebooklm_prompt(week_label: str) -> str:
+    return (
+        "NotebookLM向けの学習パックです。\n"
+        f"週次: {week_label}\n"
+        "以下のノートから、最新の高確度ポイント、争点、未確定事項を整理してください。\n"
+        "各主張には対応するPMIDとエビデンスを必ず含めてください。\n"
+    )
+
+
+def generate_weekly_pack(
+    kb_root: Path = Path("data/kb"),
+    packs_root: Path = Path("data/packs/weekly"),
+    now: Optional[datetime] = None,
+    topics: Optional[Iterable[str]] = None,
+) -> Path:
+    now = now or datetime.now(timezone.utc)
+    week_label = _iso_week_label(now)
+    week_start = datetime.fromisocalendar(now.isocalendar().year, now.isocalendar().week, 1).replace(tzinfo=timezone.utc)
+    week_end = week_start + timedelta(days=6, hours=23, minutes=59, seconds=59)
+
+    pack_dir = packs_root / week_label
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
+    notes = _collect_week_notes(kb_root, week_start, week_end, topics=topics)
+
+    readme_path = pack_dir / "README.md"
+    readme_path.write_text(_build_readme(week_label, notes), encoding="utf-8")
+
+    prompt_path = pack_dir / "notebooklm_prompt.txt"
+    prompt_path.write_text(_build_notebooklm_prompt(week_label), encoding="utf-8")
+
+    pack_path = pack_dir / "weekly_pack.zip"
+    with zipfile.ZipFile(pack_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(readme_path, arcname="README.md")
+        zf.write(prompt_path, arcname="notebooklm_prompt.txt")
+        for file in notes:
+            zf.write(file.path, arcname=file.arcname)
+
+    metadata = {
+        "week": week_label,
+        "generated_at": now.isoformat(),
+        "notes": [file.arcname for file in notes],
+    }
+    (pack_dir / "metadata.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    return pack_path

--- a/jarvis_core/ops/metrics.py
+++ b/jarvis_core/ops/metrics.py
@@ -45,6 +45,10 @@ class RunMetrics:
     # ステータス
     status: str = "running"  # running, completed, failed, degraded
 
+    # Knowledge base
+    kb_updates: int = 0
+    packs_generated: int = 0
+
 
 @dataclass
 class QualityMetrics:
@@ -124,6 +128,16 @@ class MetricsCollector:
         """degraded状態を記録."""
         if self._current_run:
             self._current_run.degraded_reasons.append(reason)
+
+    def record_kb_update(self, count: int = 1):
+        """KB更新数を記録."""
+        if self._current_run:
+            self._current_run.kb_updates += count
+
+    def record_pack_generation(self, count: int = 1):
+        """学習パック生成数を記録."""
+        if self._current_run:
+            self._current_run.packs_generated += count
     
     def update_quality(
         self,

--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -45,6 +45,8 @@ API_TOKEN = os.getenv("API_TOKEN")
 if FASTAPI_AVAILABLE:
     from jarvis_web.routes.research import router as research_router
     from jarvis_web.routes.finance import router as finance_router
+    from jarvis_web.routes.kb import router as kb_router
+    from jarvis_web.routes.packs import router as packs_router
 
     app = FastAPI(
         title="JARVIS Research OS",
@@ -63,6 +65,8 @@ if FASTAPI_AVAILABLE:
 
     app.include_router(research_router)
     app.include_router(finance_router)
+    app.include_router(kb_router)
+    app.include_router(packs_router)
 else:
     app = None
 

--- a/jarvis_web/job_runner.py
+++ b/jarvis_web/job_runner.py
@@ -318,6 +318,16 @@ def run_collect_and_ingest(job_id: str, payload: Dict[str, Any]) -> None:
 
     jobs.update_job(job_id, manifest_path=str(manifest_path))
 
+    try:
+        from jarvis_core.kb import ingest_run, generate_weekly_pack
+
+        kb_result = ingest_run(research_dir, run_id=job_id)
+        jobs.append_event(job_id, {"message": f"kb updated: {kb_result}", "level": "info"})
+        pack_path = generate_weekly_pack()
+        jobs.append_event(job_id, {"message": f"weekly pack: {pack_path}", "level": "info"})
+    except Exception as exc:  # pragma: no cover - best effort
+        jobs.append_event(job_id, {"message": f"kb update skipped: {exc}", "level": "warning"})
+
     jobs.set_progress(job_id, 100)
     jobs.set_step(job_id, "done")
     jobs.set_status(job_id, "success")

--- a/jarvis_web/routes/kb.py
+++ b/jarvis_web/routes/kb.py
@@ -1,0 +1,86 @@
+"""KB API routes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import os
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+router = APIRouter(prefix="/api/kb", tags=["kb"])
+
+KB_ROOT = Path("data/kb")
+
+
+def verify_token(authorization: Optional[str] = Header(None)) -> bool:
+    """Verify authorization token (local copy to avoid circular import)."""
+    expected = os.environ.get("JARVIS_WEB_TOKEN", "")
+    if not expected:
+        return True
+    if authorization is None:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    token = authorization.replace("Bearer ", "")
+    if token != expected:
+        raise HTTPException(status_code=403, detail="Invalid token")
+    return True
+
+
+def _load_index() -> dict:
+    path = KB_ROOT / "index.json"
+    if not path.exists():
+        return {"papers": {}, "topics": {}, "runs": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return {"papers": {}, "topics": {}, "runs": {}}
+
+
+def _read_note(path: Path) -> str:
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Note not found")
+    return path.read_text(encoding="utf-8")
+
+
+def _safe_topic_name(topic: str) -> str:
+    return topic.replace("/", "_")
+
+
+@router.get("/status")
+async def kb_status(_: bool = Depends(verify_token)):
+    """Return KB status summary."""
+    index = _load_index()
+    papers = index.get("papers", {})
+    topics = index.get("topics", {})
+    runs = index.get("runs", {})
+    last_updated: Optional[str] = None
+    for entry in list(papers.values()) + list(topics.values()) + list(runs.values()):
+        updated_at = entry.get("updated_at")
+        if updated_at and (last_updated is None or updated_at > last_updated):
+            last_updated = updated_at
+    return {
+        "papers": len(papers),
+        "topics": len(topics),
+        "runs": len(runs),
+        "last_updated": last_updated,
+        "topic_list": sorted(topics.keys()),
+    }
+
+
+@router.get("/topic/{topic}")
+async def get_topic(topic: str, _: bool = Depends(verify_token)):
+    """Fetch topic note contents."""
+    safe_topic = _safe_topic_name(topic)
+    path = KB_ROOT / "notes" / "topics" / f"{safe_topic}.md"
+    content = _read_note(path)
+    return {"topic": topic, "content": content}
+
+
+@router.get("/paper/{pmid}")
+async def get_paper(pmid: str, _: bool = Depends(verify_token)):
+    """Fetch paper note contents."""
+    path = KB_ROOT / "notes" / "papers" / f"PMID_{pmid}.md"
+    content = _read_note(path)
+    return {"pmid": pmid, "content": content}

--- a/jarvis_web/routes/packs.py
+++ b/jarvis_web/routes/packs.py
@@ -1,0 +1,82 @@
+"""Weekly pack API routes."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi.responses import FileResponse
+
+from jarvis_core.kb.weekly_pack import generate_weekly_pack
+
+router = APIRouter(prefix="/api/packs", tags=["packs"])
+
+PACKS_ROOT = Path("data/packs")
+
+
+def verify_token(authorization: Optional[str] = Header(None)) -> bool:
+    expected = os.environ.get("JARVIS_WEB_TOKEN", "")
+    if not expected:
+        return True
+    if authorization is None:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    token = authorization.replace("Bearer ", "")
+    if token != expected:
+        raise HTTPException(status_code=403, detail="Invalid token")
+    return True
+
+
+def _list_weekly_packs() -> list[dict]:
+    weekly_root = PACKS_ROOT / "weekly"
+    if not weekly_root.exists():
+        return []
+    packs = []
+    for path in sorted(weekly_root.iterdir()):
+        if not path.is_dir():
+            continue
+        metadata_path = path / "metadata.json"
+        metadata = {}
+        if metadata_path.exists():
+            try:
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                metadata = {}
+        packs.append(
+            {
+                "id": path.name,
+                "type": "weekly",
+                "path": str(path),
+                "metadata": metadata,
+            }
+        )
+    return packs
+
+
+def _resolve_pack_path(pack_id: str) -> Path:
+    safe_id = pack_id.replace("..", "").strip("/")
+    pack_path = PACKS_ROOT / "weekly" / safe_id / "weekly_pack.zip"
+    return pack_path
+
+
+@router.get("")
+async def list_packs(_: bool = Depends(verify_token)):
+    return {"packs": _list_weekly_packs()}
+
+
+@router.get("/{pack_id}/download")
+async def download_pack(pack_id: str, _: bool = Depends(verify_token)):
+    pack_path = _resolve_pack_path(pack_id)
+    if not pack_path.exists():
+        raise HTTPException(status_code=404, detail="Pack not found")
+    return FileResponse(pack_path, filename=pack_path.name)
+
+
+@router.post("/generate")
+async def generate_pack(_: bool = Depends(verify_token)):
+    try:
+        pack_path = generate_weekly_pack()
+    except Exception as exc:  # pragma: no cover - guard
+        raise HTTPException(status_code=503, detail=f"Pack generation failed: {exc}")
+    return {"status": "generated", "path": str(pack_path)}

--- a/tests/smoke_kb_api.py
+++ b/tests/smoke_kb_api.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    fastapi = pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.testclient")
+
+    from fastapi.testclient import TestClient
+    from jarvis_web import app as app_module
+    from jarvis_web.routes import kb as kb_routes
+    from jarvis_web.routes import packs as packs_routes
+
+    kb_root = tmp_path / "kb"
+    packs_root = tmp_path / "packs"
+    (kb_root / "notes" / "papers").mkdir(parents=True, exist_ok=True)
+    (kb_root / "notes" / "topics").mkdir(parents=True, exist_ok=True)
+
+    (kb_root / "notes" / "papers" / "PMID_1.md").write_text("paper", encoding="utf-8")
+    (kb_root / "notes" / "topics" / "cd73.md").write_text("topic", encoding="utf-8")
+    (kb_root / "index.json").write_text(
+        "{\"papers\": {\"1\": {\"updated_at\": \"2024-01-01T00:00:00+00:00\"}}, \"topics\": {\"cd73\": {\"updated_at\": \"2024-01-02T00:00:00+00:00\"}}, \"runs\": {}}",
+        encoding="utf-8",
+    )
+
+    pack_dir = packs_root / "weekly" / "2024-01"
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "weekly_pack.zip").write_bytes(b"zip")
+    (pack_dir / "metadata.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(kb_routes, "KB_ROOT", kb_root)
+    monkeypatch.setattr(packs_routes, "PACKS_ROOT", packs_root)
+
+    return TestClient(app_module.app)
+
+
+def test_kb_status(client):
+    response = client.get("/api/kb/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["papers"] == 1
+    assert "cd73" in payload["topic_list"]
+
+
+def test_packs_list(client):
+    response = client.get("/api/packs")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["packs"]

--- a/tests/test_kb_indexer.py
+++ b/tests/test_kb_indexer.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+from jarvis_core.kb.indexer import ingest_run
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def test_kb_indexer_preserves_manual_sections(tmp_path: Path):
+    run_dir = tmp_path / "run-1"
+    run_dir.mkdir()
+
+    papers = [
+        {
+            "pmid": "1234",
+            "title": "CD73 in the TME",
+            "abstract": "Adenosine pathway impacts tumor microenvironment.",
+            "year": 2024,
+            "journal": "Test Journal",
+            "oa": "gold",
+            "tier": "A",
+            "score": 0.9,
+        }
+    ]
+    _write_jsonl(run_dir / "papers.jsonl", papers)
+
+    claims = [
+        {
+            "paper_id": "PMID:1234",
+            "claim_id": "c1",
+            "claim_text": "CD73 increases adenosine production.",
+            "evidence": [
+                {"chunk_id": "chunk-1", "locator": "Results", "quote": "CD73 increased", "score": 0.8}
+            ],
+        }
+    ]
+    _write_jsonl(run_dir / "claims.jsonl", claims)
+
+    kb_root = tmp_path / "kb"
+    note_path = kb_root / "notes" / "papers" / "PMID_1234.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        """---
+""" +
+        "type: paper\n" +
+        "pmid: \"1234\"\n" +
+        "---\n\n" +
+        "# 自分の研究への接続\n" +
+        "- 手書きメモ\n" +
+        "<!-- AUTO-CLAIMS-START -->\n" +
+        "- 旧いclaim\n" +
+        "<!-- AUTO-CLAIMS-END -->\n",
+        encoding="utf-8",
+    )
+
+    result = ingest_run(run_dir, kb_root=kb_root, run_id="run-1")
+
+    updated = note_path.read_text(encoding="utf-8")
+    assert "手書きメモ" in updated
+    assert "CD73 increases adenosine production" in updated
+    assert result["papers"] == ["1234"]

--- a/tests/test_weekly_pack.py
+++ b/tests/test_weekly_pack.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+from pathlib import Path
+import zipfile
+
+from jarvis_core.kb.weekly_pack import generate_weekly_pack
+
+
+def test_weekly_pack_contains_notes(tmp_path: Path):
+    kb_root = tmp_path / "kb"
+    papers_dir = kb_root / "notes" / "papers"
+    topics_dir = kb_root / "notes" / "topics"
+    papers_dir.mkdir(parents=True, exist_ok=True)
+    topics_dir.mkdir(parents=True, exist_ok=True)
+
+    paper_note = papers_dir / "PMID_9999.md"
+    paper_note.write_text(
+        """---
+type: paper
+pmid: "9999"
+updated_at: "2024-01-03T00:00:00+00:00"
+---
+
+# Test
+""",
+        encoding="utf-8",
+    )
+
+    topic_note = topics_dir / "cd73.md"
+    topic_note.write_text(
+        """---
+type: topic
+topic: cd73
+updated_at: "2024-01-03T00:00:00+00:00"
+---
+
+# CD73
+""",
+        encoding="utf-8",
+    )
+
+    packs_root = tmp_path / "packs"
+    now = datetime(2024, 1, 4, tzinfo=timezone.utc)
+    pack_path = generate_weekly_pack(kb_root=kb_root, packs_root=packs_root / "weekly", now=now, topics=["cd73"])
+
+    assert pack_path.exists()
+    with zipfile.ZipFile(pack_path, "r") as zf:
+        names = set(zf.namelist())
+    assert "README.md" in names
+    assert "notes/papers/PMID_9999.md" in names
+    assert "notes/topics/cd73.md" in names


### PR DESCRIPTION
### Motivation
- Provide an Obsidian-compatible knowledge base generated from run artifacts so claims remain traceable to evidence.  
- Produce weekly learning packs (NotebookLM-ready zip) containing updated paper and topic notes for review.  
- Keep manual edits in notes intact while updating automated sections and expose KB/packs via HTTP API.  
- Surface KB state and pack download/generation in the Dashboard for easy access.

### Description
- Add a KB implementation under `jarvis_core/kb/` including `schema.py`, `indexer.py`, `normalizer.py`, `topic_router.py`, `merger.py`, `weekly_pack.py`, `citations.py`, `dedup.py`, and `quality_tags.py` to normalize terms, ingest run artifacts, merge diffs, dedupe claims, tag claim quality, and generate weekly packs.  
- Expose APIs `GET /api/kb/status`, `GET /api/kb/topic/{topic}`, `GET /api/kb/paper/{pmid}`, and `GET /api/packs` + `GET /api/packs/{id}/download` and `POST /api/packs/generate` via `jarvis_web/routes/kb.py` and `jarvis_web/routes/packs.py`, and register them in `jarvis_web/app.py`.  
- Hook KB ingestion and pack generation into run completion by calling `ingest_run` and `generate_weekly_pack` from `jarvis_web/job_runner.py`, and add KB-related counters to metrics in `jarvis_core/ops/metrics.py`.  
- Add Dashboard UI and client adapters: `dashboard/kb.html`, update `dashboard/assets/app.js` to include KB/pack API adapters, and add tests `tests/test_kb_indexer.py`, `tests/test_weekly_pack.py`, and `tests/smoke_kb_api.py` as smoke/unit coverage.

### Testing
- Running `pytest tests/test_kb_indexer.py tests/test_weekly_pack.py tests/smoke_kb_api.py` without PYTHONPATH failed during collection due to module import path (`ModuleNotFoundError: No module named 'jarvis_core'`).  
- Re-running with `PYTHONPATH=/workspace/jarvis-ml-pipeline pytest tests/test_kb_indexer.py tests/test_weekly_pack.py tests/smoke_kb_api.py` produced `2 passed, 2 skipped` where `tests/test_kb_indexer.py` and `tests/test_weekly_pack.py` passed and `tests/smoke_kb_api.py` was skipped because `fastapi`/testclient was not available in the test environment.  
- Unit tests confirm indexer preserves manual sections and weekly pack zip includes expected notes, and smoke API tests exercise listing endpoints when FastAPI is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69524bb39d108330ad72ee93fa444350)