### PR TITLE
T01: Expand dashboard IA — add Ops/KB/Search pages and update navigation

### DIFF
--- a/dashboard/decision.html
+++ b/dashboard/decision.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="decision">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/feedback.html
+++ b/dashboard/feedback.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="feedback">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="finance">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="index">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/kb.html
+++ b/dashboard/kb.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>KB - Research OS Dashboard</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body data-page="kb">
+  <nav class="top-nav">
+    <a href="index.html">Home</a>
+    <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
+    <a href="schedule.html">Schedule</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
+    <a href="settings.html">Settings</a>
+  </nav>
+  <main class="container">
+    <header class="page-header">
+      <h1>Knowledge Base</h1>
+      <p>エビデンスや社内ナレッジの一覧・タグ付けを行います。</p>
+    </header>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>KB Overview</h2>
+      </div>
+      <div class="notice">未実装: KB記事のカードやタグフィルタが表示される予定です。</div>
+    </section>
+  </main>
+
+  <script src="assets/ui.js"></script>
+  <script>
+    const setActiveNav = () => {
+      const page = document.body.dataset.page;
+      ui.qsa(".top-nav a").forEach((link) => {
+        if (link.getAttribute("href").includes(page)) {
+          link.classList.add("active");
+        }
+      });
+    };
+
+    setActiveNav();
+  </script>
+</body>
+</html>

--- a/dashboard/ops.html
+++ b/dashboard/ops.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ops - Research OS Dashboard</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body data-page="ops">
+  <nav class="top-nav">
+    <a href="index.html">Home</a>
+    <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
+    <a href="schedule.html">Schedule</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
+    <a href="settings.html">Settings</a>
+  </nav>
+  <main class="container">
+    <header class="page-header">
+      <h1>Ops</h1>
+      <p>運用状況やアラート、リカバリ導線をまとめる予定のページです。</p>
+    </header>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Ops Dashboard</h2>
+      </div>
+      <div class="notice">未実装: 運用チェックリストや障害対応メニューをここに追加します。</div>
+    </section>
+  </main>
+
+  <script src="assets/ui.js"></script>
+  <script>
+    const setActiveNav = () => {
+      const page = document.body.dataset.page;
+      ui.qsa(".top-nav a").forEach((link) => {
+        if (link.getAttribute("href").includes(page)) {
+          link.classList.add("active");
+        }
+      });
+    };
+
+    setActiveNav();
+  </script>
+</body>
+</html>

--- a/dashboard/run.html
+++ b/dashboard/run.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="run">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="runs">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/schedule.html
+++ b/dashboard/schedule.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="schedule">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">

--- a/dashboard/search.html
+++ b/dashboard/search.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Search - Research OS Dashboard</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body data-page="search">
+  <nav class="top-nav">
+    <a href="index.html">Home</a>
+    <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
+    <a href="schedule.html">Schedule</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
+    <a href="settings.html">Settings</a>
+  </nav>
+  <main class="container">
+    <header class="page-header">
+      <h1>Search</h1>
+      <p>論文・Run・ナレッジ横断検索の入口です。</p>
+    </header>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Search Hub</h2>
+      </div>
+      <div class="notice">未実装: キーワード検索やフィルタUIをここに追加します。</div>
+    </section>
+  </main>
+
+  <script src="assets/ui.js"></script>
+  <script>
+    const setActiveNav = () => {
+      const page = document.body.dataset.page;
+      ui.qsa(".top-nav a").forEach((link) => {
+        if (link.getAttribute("href").includes(page)) {
+          link.classList.add("active");
+        }
+      });
+    };
+
+    setActiveNav();
+  </script>
+</body>
+</html>

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body data-page="settings">
-  <nav class="top-nav">
+    <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="runs.html">Runs</a>
+    <a href="ops.html">Ops</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="kb.html">KB</a>
+    <a href="search.html">Search</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">


### PR DESCRIPTION
### Motivation
- Expand the dashboard information architecture to include `Ops`, `KB`, and `Search` pages alongside existing `Home`, `Runs`, `Schedule`, and `Settings` links.
- Prevent white/blank pages by providing descriptive placeholder content for unimplemented pages.
- Ensure a single shared top navigation across all dashboard pages so links do not break on GitHub Pages.
- Keep `index.html` as the Home entry while adding the new IA pages.

### Description
- Replaced the top navigation block in existing dashboard pages (`dashboard/index.html`, `dashboard/runs.html`, `dashboard/run.html`, `dashboard/schedule.html`, `dashboard/settings.html`, `dashboard/feedback.html`, `dashboard/decision.html`, `dashboard/finance.html`) with the IA links `Home / Runs / Ops / Schedule / KB / Search / Settings`.
- Added new placeholder pages `dashboard/ops.html`, `dashboard/kb.html`, and `dashboard/search.html` containing descriptive empty-state content and a `setActiveNav()` script to mark the active link.
- Updated HTML of existing pages to reference `kb.html` and `search.html` and to include `ops.html` in the navigation.
- Minor HTML formatting/alignment fixes across the modified dashboard files.

### Testing
- Served the `dashboard/` directory with `python -m http.server` and the server started successfully.
- Ran a Playwright script to open `http://127.0.0.1:8000/ops.html` and capture a screenshot, which completed and produced an artifact (`artifacts/dashboard-ops.png`).
- Performed a repository commit that updated 11 files and added the 3 new pages, which completed successfully.
- No unit or integration test suites were executed for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952537923988330bc07093fcccb69c2)