### PR TITLE
T04: add storage module and auth handling for Settings page

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -1,14 +1,12 @@
 const app = (() => {
-  const STORAGE_BASE = "JAVIS_API_BASE";
-  const STORAGE_TOKEN = "JAVIS_API_TOKEN";
-
-  const getApiBase = () => (localStorage.getItem(STORAGE_BASE) || "").trim();
-  const getApiToken = () => (localStorage.getItem(STORAGE_TOKEN) || "").trim();
-
-  const setApiConfig = (base, token) => {
-    localStorage.setItem(STORAGE_BASE, (base || "").trim());
-    localStorage.setItem(STORAGE_TOKEN, (token || "").trim());
-  };
+  const {
+    STORAGE_BASE,
+    STORAGE_TOKEN,
+    getApiBase,
+    getApiToken,
+    setApiConfig,
+    clearApiConfig,
+  } = storage;
 
   const buildUrl = (path) => {
     if (path.startsWith("http")) return path;
@@ -36,9 +34,10 @@ const app = (() => {
       ...headers,
     };
     const token = getApiToken();
-    if (token) {
-      finalHeaders.Authorization = `Bearer ${token}`;
+    if (!token) {
+      throw new Error("API_TOKENが未設定です。Settingsで設定してください。");
     }
+    finalHeaders.Authorization = `Bearer ${token}`;
     let payload = body;
     if (body && !(body instanceof FormData)) {
       finalHeaders["Content-Type"] = "application/json";
@@ -67,6 +66,13 @@ const app = (() => {
       } else {
         data = rawText;
       }
+    }
+
+    if (response.status === 401) {
+      if (!window.location.pathname.endsWith("settings.html")) {
+        window.location.href = "settings.html";
+      }
+      throw new Error("認証エラー: Settingsでトークンを設定してください。");
     }
 
     if (![200, 201].includes(response.status)) {
@@ -145,6 +151,7 @@ const app = (() => {
     getApiBase,
     getApiToken,
     setApiConfig,
+    clearApiConfig,
     apiFetch,
     apiFetchSafe,
     resolveFileUrl,

--- a/dashboard/assets/storage.js
+++ b/dashboard/assets/storage.js
@@ -1,0 +1,38 @@
+const storage = (() => {
+  const STORAGE_BASE = "JAVIS_API_BASE";
+  const STORAGE_TOKEN = "JAVIS_API_TOKEN";
+
+  const getItem = (key) => (localStorage.getItem(key) || "").trim();
+  const setItem = (key, value) => {
+    const trimmed = (value || "").trim();
+    if (trimmed) {
+      localStorage.setItem(key, trimmed);
+    } else {
+      localStorage.removeItem(key);
+    }
+  };
+
+  const getApiBase = () => getItem(STORAGE_BASE);
+  const getApiToken = () => getItem(STORAGE_TOKEN);
+
+  const setApiConfig = (base, token) => {
+    setItem(STORAGE_BASE, base);
+    setItem(STORAGE_TOKEN, token);
+  };
+
+  const clearApiConfig = () => {
+    localStorage.removeItem(STORAGE_BASE);
+    localStorage.removeItem(STORAGE_TOKEN);
+  };
+
+  return {
+    STORAGE_BASE,
+    STORAGE_TOKEN,
+    getApiBase,
+    getApiToken,
+    setApiConfig,
+    clearApiConfig,
+  };
+})();
+
+window.storage = storage;

--- a/dashboard/decision.html
+++ b/dashboard/decision.html
@@ -40,6 +40,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/feedback.html
+++ b/dashboard/feedback.html
@@ -44,6 +44,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -40,6 +40,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -72,6 +72,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/run.html
+++ b/dashboard/run.html
@@ -138,6 +138,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -73,6 +73,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/schedule.html
+++ b/dashboard/schedule.html
@@ -147,6 +147,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -33,6 +33,7 @@
       <div class="flex">
         <button id="save-settings">保存</button>
         <button class="secondary" id="test-connection">接続テスト</button>
+        <button class="secondary" id="clear-settings">削除</button>
       </div>
       <div id="settings-status" class="notice">未保存</div>
     </section>
@@ -51,6 +52,7 @@
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>
@@ -77,7 +79,14 @@
         const response = await app.apiFetchSafe("/api/health");
         ui.qs("#settings-status").textContent = response.ok
           ? "接続OK"
-          : "API_BASE or TOKENが誤り";
+          : `接続失敗: ${response.error.message}`;
+      });
+
+      ui.qs("#clear-settings").addEventListener("click", () => {
+        app.clearApiConfig();
+        ui.qs("#api-base").value = "";
+        ui.qs("#api-token").value = "";
+        ui.qs("#settings-status").textContent = "削除しました";
       });
     };
 


### PR DESCRIPTION
### Motivation
- Provide centralized LocalStorage management for API base and token to avoid duplicated access logic across pages. 
- Prevent accidental API calls when token is not set and ensure graceful degradation and redirection on authentication failure. 
- Improve Settings UI to allow clearing saved credentials and show clearer diagnostics for connection tests. 

### Description
- Added a `dashboard/assets/storage.js` module that exposes `getApiBase`, `getApiToken`, `setApiConfig`, and `clearApiConfig`, and trims/cleans stored values. 
- Updated `dashboard/assets/app.js` to use the `storage` module, always require an API token before sending requests (`apiFetch` throws if token missing), attach `Authorization: Bearer <token>`, and redirect to `settings.html` on HTTP `401`. 
- Updated `dashboard/settings.html` to include `storage.js`, add a `削除` (clear) button wired to `clearApiConfig`, and show detailed error text from `apiFetchSafe` for connection tests. 
- Injected `storage.js` include into other dashboard pages (`index.html`, `run.html`, `runs.html`, `schedule.html`, `feedback.html`, `decision.html`, `finance.html`) so all pages share the same storage/auth handling. 

### Testing
- Launched a local static server with `python -m http.server` and executed a Playwright script to open `settings.html` and capture a screenshot, which completed and produced `artifacts/settings.png`. 
- Performed static verification that `storage.js` is included in all dashboard pages by searching updated HTML files, which succeeded. 
- No unit tests were added or run for JavaScript functions in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695253b940608330ba59392a52f3808c)