### PR TITLE
T05: Normalize run creation UI to /api/runs

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -117,6 +117,7 @@ const app = (() => {
   const getRunEventsUrl = (runId) => buildUrl(`/api/runs/${runId}/events`);
   const getHealth = () => apiFetch("/api/health");
   const getCronHealth = () => apiFetch("/api/health/cron");
+  const createRun = (payload) => apiFetch("/api/runs", { method: "POST", body: payload });
   const getRank = (runId, topK = 50) =>
     apiFetch(`/api/research/rank?run_id=${encodeURIComponent(runId)}&top_k=${topK}`);
   const getPaper = (runId, paperId) =>
@@ -154,6 +155,7 @@ const app = (() => {
     getRunEventsUrl,
     getHealth,
     getCronHealth,
+    createRun,
     getRank,
     getPaper,
     getQaReport,

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -24,6 +24,21 @@
 
     <section class="panel">
       <div class="section-title">
+        <h2>Run作成</h2>
+      </div>
+      <div class="form-row">
+        <input id="run-query" placeholder="query" />
+        <input id="run-max-papers" type="number" min="1" value="10" />
+        <input id="run-seed" type="number" value="42" />
+      </div>
+      <div class="flex">
+        <button id="create-run">Run作成</button>
+      </div>
+      <div class="notice" id="create-run-status">未実行</div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
         <h2>Filters</h2>
         <button class="secondary" id="refresh-runs">更新</button>
       </div>
@@ -112,6 +127,32 @@
       });
     };
 
+    const createRun = async () => {
+      const statusEl = ui.qs("#create-run-status");
+      const query = ui.qs("#run-query").value.trim();
+      if (!query) {
+        statusEl.textContent = "queryを入力してください。";
+        return;
+      }
+      statusEl.textContent = "作成中...";
+      const maxPapersValue = parseInt(ui.qs("#run-max-papers").value, 10);
+      const seedValue = parseInt(ui.qs("#run-seed").value, 10);
+      const payload = {
+        query,
+        max_papers: Number.isFinite(maxPapersValue) ? maxPapersValue : 10,
+        seed: Number.isFinite(seedValue) ? seedValue : 42,
+      };
+
+      const response = await app.apiFetchSafe("/api/runs", { method: "POST", body: payload });
+      if (!response.ok) {
+        statusEl.textContent = "未実装/未接続";
+        return;
+      }
+      const runId = response.data?.run_id || response.data?.id || "-";
+      statusEl.textContent = `作成完了: ${runId}`;
+      renderRuns();
+    };
+
     const renderRuns = async () => {
       const statusEl = ui.qs("#runs-status");
       const tableBody = ui.qs("#runs-table tbody");
@@ -159,6 +200,7 @@
         ui.qs(selector).addEventListener("change", renderRuns);
         ui.qs(selector).addEventListener("keyup", renderRuns);
       });
+      ui.qs("#create-run").addEventListener("click", createRun);
       ui.qs("#refresh-runs").addEventListener("click", renderRuns);
     };
 

--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -422,14 +422,13 @@ if FASTAPI_AVAILABLE:
         """Decision simulate not yet implemented."""
         raise HTTPException(status_code=501, detail="Decision simulate not implemented")
 
-    @app.post("/api/run", response_model=RunResponse)
-    async def start_run(request: RunRequest, _: bool = Depends(verify_token)):
+    def _start_run(request: RunRequest) -> RunResponse:
         """Start a new paper survey run."""
         import uuid
         from jarvis_core.app import run_task
 
         run_id = str(uuid.uuid4())
-        
+
         try:
             result = run_task(
                 task_dict={
@@ -442,7 +441,7 @@ if FASTAPI_AVAILABLE:
                     **request.config,
                 },
             )
-            
+
             return RunResponse(
                 run_id=result.run_id,
                 status=result.status,
@@ -454,6 +453,16 @@ if FASTAPI_AVAILABLE:
                 status="error",
                 message=str(e),
             )
+
+    @app.post("/api/runs", response_model=RunResponse)
+    async def start_run(request: RunRequest, _: bool = Depends(verify_token)):
+        """Start a new paper survey run."""
+        return _start_run(request)
+
+    @app.post("/api/run", response_model=RunResponse)
+    async def start_run_legacy(request: RunRequest, _: bool = Depends(verify_token)):
+        """Legacy start run endpoint."""
+        return _start_run(request)
 
     # === File Upload (AG-07) ===
 


### PR DESCRIPTION
### Motivation
- Align the dashboard Run creation flow with the v1 API contract by using `/api/runs` instead of the legacy `/api/run` endpoint.  
- Provide a minimal, graceful Run creation UI on the Runs page so users can create runs without the old compatibility-only path.  
- Keep legacy compatibility while moving the canonical contract to P14-style endpoints to avoid breaking existing integrations.  

### Description
- Added a canonical POST handler `@app.post("/api/runs")` backed by a shared `_start_run` implementation and retained `/api/run` as a legacy alias in `jarvis_web/app.py`.  
- Exposed a new client helper `createRun` in `dashboard/assets/app.js` that performs `POST /api/runs`.  
- Implemented a minimal Run creation form and client flow in `dashboard/runs.html` that collects `query`, `max_papers`, and `seed`, calls the API, updates status, and refreshes the runs list.  
- Kept existing runs listing and detail code paths unchanged and wired the new form button to call the create routine.  

### Testing
- Started a local static server with `python -m http.server 8000` and ran a Playwright smoke test that loaded `http://127.0.0.1:8000/runs.html` and saved a screenshot to `artifacts/runs-create.png`, which succeeded under Firefox.  
- A Chromium-based Playwright run failed to launch in the environment due to browser startup errors, and was retried with Firefox which produced the successful artifact.  
- No unit tests or test-suite runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952542982ec8330b5a8cc6b0802cb62)