### PR TITLE
T03: Capability-driven UI (auto-disable unavailable features)

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -86,6 +86,35 @@ const app = (() => {
     }
   };
 
+  let capabilitiesCache = null;
+  let capabilitiesPromise = null;
+
+  const getCapabilities = async () => {
+    if (capabilitiesCache) {
+      return { ok: true, data: capabilitiesCache };
+    }
+    if (!getApiBase()) {
+      return { ok: false, error: new Error("API_BASEが未設定です。Settingsで設定してください。") };
+    }
+    if (capabilitiesPromise) {
+      return capabilitiesPromise;
+    }
+    capabilitiesPromise = apiFetchSafe("/api/capabilities").then((result) => {
+      if (result.ok) {
+        capabilitiesCache = result.data;
+      }
+      return result;
+    }).finally(() => {
+      capabilitiesPromise = null;
+    });
+    return capabilitiesPromise;
+  };
+
+  const isFeatureEnabled = (capabilities, featureKey) => {
+    if (!capabilities || !capabilities.features) return false;
+    return Boolean(capabilities.features[featureKey]);
+  };
+
   const resolveFileUrl = (runId, file) => {
     if (!file) return null;
     if (typeof file === "string") {
@@ -171,6 +200,8 @@ const app = (() => {
     decisionSimulate,
     financeOptimize,
     buildUrl,
+    getCapabilities,
+    isFeatureEnabled,
   };
 })();
 

--- a/dashboard/assets/ui.js
+++ b/dashboard/assets/ui.js
@@ -55,6 +55,18 @@ const ui = (() => {
     }
   };
 
+  const applyCapabilitiesToNav = (capabilities) => {
+    if (!capabilities || !capabilities.features) return;
+    qsa(".top-nav a[data-feature]").forEach((link) => {
+      const featureKey = link.dataset.feature;
+      if (!featureKey) return;
+      if (!window.app || !window.app.isFeatureEnabled) return;
+      if (!window.app.isFeatureEnabled(capabilities, featureKey)) {
+        link.style.display = "none";
+      }
+    });
+  };
+
   return {
     qs,
     qsa,
@@ -65,6 +77,7 @@ const ui = (() => {
     formatNumber,
     renderList,
     copyToClipboard,
+    applyCapabilitiesToNav,
   };
 })();
 

--- a/dashboard/decision.html
+++ b/dashboard/decision.html
@@ -9,11 +9,11 @@
 <body data-page="decision">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -52,6 +52,9 @@
       });
     };
 
+    let decisionEnabled = true;
+    let capabilityStatus = "available";
+
     const parseJson = (value) => {
       try {
         return value ? JSON.parse(value) : null;
@@ -60,9 +63,36 @@
       }
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        decisionEnabled = app.isFeatureEnabled(result.data, "decision");
+        capabilityStatus = decisionEnabled ? "available" : "unavailable";
+      } else {
+        decisionEnabled = false;
+        capabilityStatus = "disconnected";
+        ui.applyCapabilitiesToNav({});
+      }
+      if (!decisionEnabled) {
+        ui.qsa(".panel").forEach((panel) => {
+          panel.style.display = "none";
+        });
+        const main = ui.qs("main.container");
+        const notice = ui.el("div", { className: "notice", text: capabilityStatus === "unavailable" ? "未実装" : "未接続" });
+        main.appendChild(notice);
+      }
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       ui.qs("#run-decision").addEventListener("click", async () => {
+        if (!decisionEnabled) {
+          ui.qs("#decision-status").textContent = capabilityStatus === "unavailable" ? "未実装" : "未接続";
+          ui.qs("#decision-result").textContent = "";
+          return;
+        }
         const options = parseJson(ui.qs("#decision-options").value);
         const assumptions = parseJson(ui.qs("#decision-assumptions").value);
         if (!options) {

--- a/dashboard/feedback.html
+++ b/dashboard/feedback.html
@@ -9,11 +9,11 @@
 <body data-page="feedback">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -56,10 +56,19 @@
       });
     };
 
+    let feedbackEnabled = true;
+    let capabilityStatus = "available";
+
     const renderRisk = async () => {
       const runId = ui.qs("#feedback-run").value.trim();
       const kpi = ui.qs("#risk-kpi");
       const high = ui.qs("#risk-high");
+      if (!feedbackEnabled) {
+        kpi.innerHTML = "";
+        high.innerHTML = "";
+        high.appendChild(ui.el("div", { className: "notice", text: capabilityStatus === "unavailable" ? "未実装" : "未接続" }));
+        return;
+      }
       kpi.innerHTML = "";
       high.innerHTML = "";
       if (!runId) {
@@ -102,10 +111,36 @@
       });
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        feedbackEnabled = app.isFeatureEnabled(result.data, "feedback");
+        capabilityStatus = feedbackEnabled ? "available" : "unavailable";
+      } else {
+        feedbackEnabled = false;
+        capabilityStatus = "disconnected";
+        ui.applyCapabilitiesToNav({});
+      }
+      if (!feedbackEnabled) {
+        ui.qsa(".panel").forEach((panel) => {
+          panel.style.display = "none";
+        });
+        const main = ui.qs("main.container");
+        const notice = ui.el("div", { className: "notice", text: capabilityStatus === "unavailable" ? "未実装" : "未接続" });
+        main.appendChild(notice);
+      }
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       ui.qs("#refresh-risk").addEventListener("click", renderRisk);
       ui.qs("#import-feedback").addEventListener("click", async () => {
+        if (!feedbackEnabled) {
+          ui.qs("#feedback-status").textContent = capabilityStatus === "unavailable" ? "未実装" : "未接続";
+          return;
+        }
         const payload = {
           run_id: ui.qs("#feedback-run").value.trim(),
           content: ui.qs("#feedback-input").value,

--- a/dashboard/finance.html
+++ b/dashboard/finance.html
@@ -9,11 +9,11 @@
 <body data-page="finance">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -52,6 +52,9 @@
       });
     };
 
+    let financeEnabled = true;
+    let capabilityStatus = "available";
+
     const parseJson = (value) => {
       try {
         return value ? JSON.parse(value) : null;
@@ -60,9 +63,36 @@
       }
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        financeEnabled = app.isFeatureEnabled(result.data, "finance");
+        capabilityStatus = financeEnabled ? "available" : "unavailable";
+      } else {
+        financeEnabled = false;
+        capabilityStatus = "disconnected";
+        ui.applyCapabilitiesToNav({});
+      }
+      if (!financeEnabled) {
+        ui.qsa(".panel").forEach((panel) => {
+          panel.style.display = "none";
+        });
+        const main = ui.qs("main.container");
+        const notice = ui.el("div", { className: "notice", text: capabilityStatus === "unavailable" ? "未実装" : "未接続" });
+        main.appendChild(notice);
+      }
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       ui.qs("#run-finance").addEventListener("click", async () => {
+        if (!financeEnabled) {
+          ui.qs("#finance-status").textContent = capabilityStatus === "unavailable" ? "未実装" : "未接続";
+          ui.qs("#finance-result").textContent = "";
+          return;
+        }
         const cashflow = parseJson(ui.qs("#finance-cashflow").value);
         const time = parseJson(ui.qs("#finance-time").value);
         if (!cashflow) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9,11 +9,11 @@
 <body data-page="index">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -83,6 +83,8 @@
         }
       });
     };
+
+    let runsEnabled = true;
 
     const renderHealth = async () => {
       const healthEl = ui.qs("#health-status");
@@ -179,15 +181,44 @@
       });
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        runsEnabled = app.isFeatureEnabled(result.data, "runs");
+        if (!runsEnabled) {
+          ui.qs("#kpi-grid").innerHTML = "";
+          ui.qs("#kpi-grid").appendChild(ui.el("div", { className: "notice", text: "未実装" }));
+          ui.qs("#latest-runs tbody").innerHTML = "";
+          const empty = ui.qs("#latest-runs-empty");
+          empty.textContent = "未実装";
+          empty.style.display = "block";
+        }
+        return;
+      }
+      runsEnabled = false;
+      ui.applyCapabilitiesToNav({});
+      ui.qs("#kpi-grid").innerHTML = "";
+      ui.qs("#kpi-grid").appendChild(ui.el("div", { className: "notice", text: "未接続" }));
+      const empty = ui.qs("#latest-runs-empty");
+      empty.textContent = "未接続";
+      empty.style.display = "block";
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       renderHealth();
-      renderKpi();
-      renderLatestRuns();
-      ui.qs("#refresh-health").addEventListener("click", renderHealth);
-      ui.qs("#refresh-kpi").addEventListener("click", () => {
+      if (runsEnabled) {
         renderKpi();
         renderLatestRuns();
+      }
+      ui.qs("#refresh-health").addEventListener("click", renderHealth);
+      ui.qs("#refresh-kpi").addEventListener("click", () => {
+        if (runsEnabled) {
+          renderKpi();
+          renderLatestRuns();
+        }
       });
     };
 

--- a/dashboard/run.html
+++ b/dashboard/run.html
@@ -9,11 +9,11 @@
 <body data-page="run">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -26,11 +26,11 @@
       <div class="tabs">
         <button class="active" data-tab="overview">Overview</button>
         <button data-tab="progress">Progress & Logs</button>
-        <button data-tab="papers">Papers (Rank)</button>
-        <button data-tab="claims">Claims & Evidence</button>
-        <button data-tab="qa">QA Report</button>
+        <button data-tab="papers" data-feature="research_rank">Papers (Rank)</button>
+        <button data-tab="claims" data-feature="research_paper">Claims & Evidence</button>
+        <button data-tab="qa" data-feature="qa_report">QA Report</button>
         <button data-tab="exports">Exports</button>
-        <button data-tab="submission">Submission</button>
+        <button data-tab="submission" data-feature="submission">Submission</button>
       </div>
 
       <div id="tab-overview" class="tab-content active">
@@ -60,7 +60,7 @@
         <pre id="run-logs">ログ待機中...</pre>
       </div>
 
-      <div id="tab-papers" class="tab-content">
+      <div id="tab-papers" class="tab-content" data-feature="research_rank">
         <div class="section-title">
           <h2>Ranked Papers</h2>
           <button class="secondary" id="refresh-papers">更新</button>
@@ -69,7 +69,7 @@
         <div id="papers-content"></div>
       </div>
 
-      <div id="tab-claims" class="tab-content">
+      <div id="tab-claims" class="tab-content" data-feature="research_paper">
         <div class="section-title">
           <h2>Claims & Evidence</h2>
           <div class="flex">
@@ -81,7 +81,7 @@
         <div id="claims-content"></div>
       </div>
 
-      <div id="tab-qa" class="tab-content">
+      <div id="tab-qa" class="tab-content" data-feature="qa_report">
         <div class="section-title">
           <h2>QA Report</h2>
           <button class="secondary" id="refresh-qa">更新</button>
@@ -100,7 +100,7 @@
         <div id="exports-list"></div>
       </div>
 
-      <div id="tab-submission" class="tab-content">
+      <div id="tab-submission" class="tab-content" data-feature="submission">
         <div class="section-title">
           <h2>Submission</h2>
           <button class="secondary" id="refresh-submission">更新</button>
@@ -145,6 +145,14 @@
     const defaultRun = { files: [] };
     let runData = defaultRun;
     let poller = null;
+    let features = {
+      research_rank: true,
+      research_paper: true,
+      qa_report: true,
+      submission: true,
+      events: true,
+    };
+    let capabilityStatus = "available";
 
     const setActiveNav = () => {
       ui.qsa(".top-nav a").forEach((link) => {
@@ -163,6 +171,21 @@
           ui.qs(`#tab-${button.dataset.tab}`).classList.add("active");
         });
       });
+    };
+
+    const capabilityFallbackLabel = () => (capabilityStatus === "disconnected" ? "未接続" : "未実装");
+
+    const setFeatureVisibility = (featureKey, enabled) => {
+      ui.qsa(`[data-feature="${featureKey}"]`).forEach((el) => {
+        el.style.display = enabled ? "" : "none";
+      });
+      const active = ui.qs(".tabs button.active");
+      if (active && active.style.display === "none") {
+        const overview = ui.qs('.tabs button[data-tab="overview"]');
+        if (overview) {
+          overview.click();
+        }
+      }
     };
 
     const updateOverview = () => {
@@ -296,6 +319,11 @@
     const renderPapers = async () => {
       const status = ui.qs("#papers-status");
       const content = ui.qs("#papers-content");
+      if (!features.research_rank) {
+        status.textContent = capabilityFallbackLabel();
+        content.innerHTML = "";
+        return;
+      }
       status.textContent = "読み込み中...";
       content.innerHTML = "";
 
@@ -344,6 +372,11 @@
       const paperId = ui.qs("#paper-id").value.trim();
       const status = ui.qs("#claims-status");
       const content = ui.qs("#claims-content");
+      if (!features.research_paper) {
+        status.textContent = capabilityFallbackLabel();
+        content.innerHTML = "";
+        return;
+      }
       status.textContent = "読み込み中...";
       content.innerHTML = "";
       if (!paperId) {
@@ -388,6 +421,11 @@
     const renderQa = async () => {
       const status = ui.qs("#qa-status");
       const content = ui.qs("#qa-content");
+      if (!features.qa_report) {
+        status.textContent = capabilityFallbackLabel();
+        content.innerHTML = "";
+        return;
+      }
       status.textContent = "読み込み中...";
       content.innerHTML = "";
       let data = null;
@@ -458,6 +496,15 @@
     const renderSubmission = async () => {
       const latestEl = ui.qs("#submission-latest");
       const linkEl = ui.qs("#submission-links");
+      if (!features.submission) {
+        const label = capabilityFallbackLabel();
+        latestEl.textContent = label;
+        ui.qs("#submission-changelog").textContent = label;
+        ui.qs("#submission-email").textContent = label;
+        ui.qs("#build-status").textContent = label;
+        linkEl.innerHTML = "";
+        return;
+      }
       latestEl.textContent = "読み込み中...";
       linkEl.innerHTML = "";
 
@@ -478,15 +525,77 @@
       ui.qs("#submission-email").textContent = email.ok ? JSON.stringify(email.data, null, 2) : "未実装/未接続";
     };
 
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        features = {
+          research_rank: app.isFeatureEnabled(result.data, "research_rank"),
+          research_paper: app.isFeatureEnabled(result.data, "research_paper"),
+          qa_report: app.isFeatureEnabled(result.data, "qa_report"),
+          submission: app.isFeatureEnabled(result.data, "submission"),
+          events: app.isFeatureEnabled(result.data, "events"),
+        };
+        capabilityStatus = "available";
+        setFeatureVisibility("research_rank", features.research_rank);
+        setFeatureVisibility("research_paper", features.research_paper);
+        setFeatureVisibility("qa_report", features.qa_report);
+        setFeatureVisibility("submission", features.submission);
+        if (!features.research_rank) {
+          ui.qs("#papers-status").textContent = "未実装";
+        }
+        if (!features.research_paper) {
+          ui.qs("#claims-status").textContent = "未実装";
+        }
+        if (!features.qa_report) {
+          ui.qs("#qa-status").textContent = "未実装";
+        }
+        if (!features.submission) {
+          ui.qs("#submission-latest").textContent = "未実装";
+          ui.qs("#submission-changelog").textContent = "未実装";
+          ui.qs("#submission-email").textContent = "未実装";
+          ui.qs("#build-status").textContent = "未実装";
+        }
+        return;
+      }
+      ui.applyCapabilitiesToNav({});
+      capabilityStatus = "disconnected";
+      features = {
+        research_rank: false,
+        research_paper: false,
+        qa_report: false,
+        submission: false,
+        events: false,
+      };
+      ui.qs("#papers-status").textContent = "未接続";
+      ui.qs("#claims-status").textContent = "未接続";
+      ui.qs("#qa-status").textContent = "未接続";
+      ui.qs("#submission-latest").textContent = "未接続";
+      ui.qs("#submission-changelog").textContent = "未接続";
+      ui.qs("#submission-email").textContent = "未接続";
+      ui.qs("#build-status").textContent = "未接続";
+    };
+
     const init = async () => {
       setActiveNav();
       setTabs();
+      await applyCapabilities();
       await loadRun();
-      startSse();
-      renderPapers();
+      if (features.events) {
+        startSse();
+      } else {
+        startPolling();
+      }
+      if (features.research_rank) {
+        renderPapers();
+      }
       renderExports();
-      renderQa();
-      renderSubmission();
+      if (features.qa_report) {
+        renderQa();
+      }
+      if (features.submission) {
+        renderSubmission();
+      }
 
       ui.qs("#refresh-progress").addEventListener("click", loadRun);
       ui.qs("#refresh-papers").addEventListener("click", renderPapers);
@@ -496,6 +605,10 @@
       ui.qs("#refresh-submission").addEventListener("click", renderSubmission);
 
       ui.qs("#build-submission").addEventListener("click", async () => {
+        if (!features.submission) {
+          ui.qs("#build-status").textContent = capabilityFallbackLabel();
+          return;
+        }
         const payload = {
           run_id: runId,
           submission_version: ui.qs("#submission-version").value,

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -9,11 +9,11 @@
 <body data-page="runs">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -85,6 +85,9 @@
       });
     };
 
+    let runsEnabled = true;
+    let runsCapabilityStatus = "available";
+
     const getFilters = () => ({
       status: ui.qs("#filter-status").value,
       qa: ui.qs("#filter-qa").value,
@@ -117,6 +120,13 @@
       const tableBody = ui.qs("#runs-table tbody");
       const emptyEl = ui.qs("#runs-empty");
       const countEl = ui.qs("#runs-count");
+      if (!runsEnabled) {
+        statusEl.textContent = runsCapabilityStatus === "unavailable" ? "未実装" : "未接続";
+        tableBody.innerHTML = "";
+        emptyEl.style.display = "block";
+        countEl.textContent = "0";
+        return;
+      }
       statusEl.textContent = "データ取得中...";
       tableBody.innerHTML = "";
 
@@ -152,8 +162,36 @@
       });
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        runsEnabled = app.isFeatureEnabled(result.data, "runs");
+        runsCapabilityStatus = runsEnabled ? "available" : "unavailable";
+        if (!runsEnabled) {
+          ui.qsa(".panel").forEach((panel) => {
+            panel.style.display = "none";
+          });
+          const main = ui.qs("main.container");
+          const notice = ui.el("div", { className: "notice", text: "未実装" });
+          main.appendChild(notice);
+        }
+        return;
+      }
+      runsEnabled = false;
+      runsCapabilityStatus = "disconnected";
+      ui.applyCapabilitiesToNav({});
+      ui.qsa(".panel").forEach((panel) => {
+        panel.style.display = "none";
+      });
+      const main = ui.qs("main.container");
+      const notice = ui.el("div", { className: "notice", text: "未接続" });
+      main.appendChild(notice);
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       renderRuns();
       ["#filter-status", "#filter-qa", "#filter-package", "#filter-keyword"].forEach((selector) => {
         ui.qs(selector).addEventListener("change", renderRuns);

--- a/dashboard/schedule.html
+++ b/dashboard/schedule.html
@@ -9,11 +9,11 @@
 <body data-page="schedule">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -257,8 +257,18 @@
       });
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        return;
+      }
+      ui.applyCapabilitiesToNav({});
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       renderSchedules();
       ui.qs("#refresh-schedule").addEventListener("click", renderSchedules);
       ui.qs("#schedule-rrule-preset").addEventListener("change", (event) => {

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -9,11 +9,11 @@
 <body data-page="settings">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="runs.html">Runs</a>
+    <a href="runs.html" data-feature="runs">Runs</a>
     <a href="schedule.html">Schedule</a>
-    <a href="feedback.html">Feedback Risk</a>
-    <a href="decision.html">Decision</a>
-    <a href="finance.html">Finance</a>
+    <a href="feedback.html" data-feature="feedback">Feedback Risk</a>
+    <a href="decision.html" data-feature="decision">Decision</a>
+    <a href="finance.html" data-feature="finance">Finance</a>
     <a href="settings.html">Settings</a>
   </nav>
   <main class="container">
@@ -63,8 +63,18 @@
       });
     };
 
-    const init = () => {
+    const applyCapabilities = async () => {
+      const result = await app.getCapabilities();
+      if (result.ok) {
+        ui.applyCapabilitiesToNav(result.data);
+        return;
+      }
+      ui.applyCapabilitiesToNav({});
+    };
+
+    const init = async () => {
       setActiveNav();
+      await applyCapabilities();
       ui.qs("#api-base").value = app.getApiBase();
       ui.qs("#api-token").value = app.getApiToken();
 


### PR DESCRIPTION
### Motivation
- Respect server-reported capabilities from `/api/capabilities` so the dashboard only exposes supported features.  
- Prevent UI crashes and avoid making requests to endpoints that are `501`/`404`/unavailable.  
- Provide graceful degradation by showing `未実装` or `未接続` instead of blank pages.  
- Avoid accidental requests when `API_BASE` is not configured.  

### Description
- Added cached capability lookup helpers `getCapabilities` and `isFeatureEnabled` to `dashboard/assets/app.js` with request deduplication.  
- Added `ui.applyCapabilitiesToNav` in `dashboard/assets/ui.js` and introduced `data-feature` attributes on nav links and tabs to allow hiding disabled features.  
- Updated multiple pages (`index.html`, `runs.html`, `run.html`, `feedback.html`, `decision.html`, `finance.html`, `schedule.html`, `settings.html`) to call `app.getCapabilities`, gate UI pieces, display `未実装`/`未接続`, and avoid triggering API calls for disabled features.  
- Improved `run.html` behavior to hide unavailable tabs, show fallback labels, and fall back to polling when SSE/events are not available.  

### Testing
- Started a static server and ran a Playwright script to load `dashboard/index.html` and capture a screenshot, which completed successfully.  
- Verified the index page displays capability-driven notices and that disabled features are hidden in the rendered screenshot/local run.  
- No unit tests were added and no other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952540b3138833094302df1e5e95a60)