### PR TITLE
T06: Consolidate Runs listing into runs.html

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -51,24 +51,10 @@
 
     <section class="panel">
       <div class="section-title">
-        <h2>Latest Runs</h2>
-        <a class="badge" href="runs.html">一覧へ</a>
+        <h2>Runs</h2>
+        <a class="badge" href="runs.html">runs.htmlへ</a>
       </div>
-      <table class="table" id="latest-runs">
-        <thead>
-          <tr>
-            <th>Run ID</th>
-            <th>Status</th>
-            <th>Progress</th>
-            <th>Tier Summary</th>
-            <th>QA</th>
-            <th>Submission</th>
-            <th>Created</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-      <div id="latest-runs-empty" class="notice">データがありません。</div>
+      <div class="notice">Runs一覧は runs.html で確認してください。</div>
     </section>
   </main>
 
@@ -149,46 +135,12 @@
       });
     };
 
-    const renderLatestRuns = async () => {
-      const tableBody = ui.qs("#latest-runs tbody");
-      const empty = ui.qs("#latest-runs-empty");
-      tableBody.innerHTML = "";
-      const runs = await app.apiFetchSafe("/api/runs");
-      if (!runs.ok) {
-        empty.textContent = "未接続";
-        empty.style.display = "block";
-        return;
-      }
-      const list = (runs.data || []).slice(0, 5);
-      if (!list.length) {
-        empty.style.display = "block";
-        return;
-      }
-      empty.style.display = "none";
-      list.forEach((run) => {
-        const row = ui.el("tr");
-        const idLink = ui.el("a", { text: run.id || run.run_id || "-", attrs: { href: `run.html?id=${run.id || run.run_id}` } });
-        row.appendChild(ui.el("td", { html: idLink.outerHTML }));
-        row.appendChild(ui.el("td", { text: run.status || "-" }));
-        row.appendChild(ui.el("td", { text: run.progress || run.step || "-" }));
-        row.appendChild(ui.el("td", { text: run.tier_summary || "-" }));
-        row.appendChild(ui.el("td", { text: run.qa_status || run.qa_ready || "-" }));
-        row.appendChild(ui.el("td", { text: run.submission_status || "-" }));
-        row.appendChild(ui.el("td", { text: ui.formatDateTime(run.created_at) }));
-        tableBody.appendChild(row);
-      });
-    };
-
     const init = () => {
       setActiveNav();
       renderHealth();
       renderKpi();
-      renderLatestRuns();
       ui.qs("#refresh-health").addEventListener("click", renderHealth);
-      ui.qs("#refresh-kpi").addEventListener("click", () => {
-        renderKpi();
-        renderLatestRuns();
-      });
+      ui.qs("#refresh-kpi").addEventListener("click", renderKpi);
     };
 
     init();

--- a/dashboard/runs.html
+++ b/dashboard/runs.html
@@ -112,6 +112,12 @@
       });
     };
 
+    const listRuns = async () => {
+      const response = await app.apiFetchSafe("/api/runs");
+      if (!response.ok) return response;
+      return { ...response, data: Array.isArray(response.data) ? response.data : [] };
+    };
+
     const renderRuns = async () => {
       const statusEl = ui.qs("#runs-status");
       const tableBody = ui.qs("#runs-table tbody");
@@ -120,7 +126,7 @@
       statusEl.textContent = "データ取得中...";
       tableBody.innerHTML = "";
 
-      const response = await app.apiFetchSafe("/api/runs");
+      const response = await listRuns();
       if (!response.ok) {
         statusEl.textContent = "未実装/未接続";
         emptyEl.style.display = "block";


### PR DESCRIPTION
### Motivation
- Centralize run list fetching and rendering in `runs.html` to remove duplicated Runs UI on the home dashboard.
- Reduce duplicated API calls and simplify maintenance by making `runs.html` the single source of truth for Runs display.
- Make the index page a lightweight pointer to the canonical `runs.html` listing.

### Description
- Add a `listRuns` helper in `dashboard/runs.html` that calls `app.apiFetchSafe("/api/runs")` and normalizes `data` to an array.
- Update `renderRuns` in `dashboard/runs.html` to use the new `listRuns` helper.
- Remove the embedded Runs table and the `renderLatestRuns` function from `dashboard/index.html` and replace it with a notice pointing users to `runs.html`, and update the KPI refresh handler accordingly.
- Adjust link text to explicitly reference `runs.html` for clarity.

### Testing
- Performed a visual smoke test by serving `dashboard` with `python -m http.server` and capturing a Playwright screenshot of `dashboard/index.html`, which completed successfully.
- No automated unit or integration tests were added or executed for these static HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69525457e2148330885d77b25f371bfc)