### PR TITLE
T08: Add artifact download UI and recommended download buttons

### DIFF
--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -114,6 +114,7 @@ const app = (() => {
 
   const listRuns = () => apiFetch("/api/runs");
   const getRun = (runId) => apiFetch(`/api/runs/${runId}`);
+  const listRunFiles = (runId) => apiFetch(`/api/runs/${runId}/files`);
   const getRunEventsUrl = (runId) => buildUrl(`/api/runs/${runId}/events`);
   const getHealth = () => apiFetch("/api/health");
   const getCronHealth = () => apiFetch("/api/health/cron");
@@ -151,6 +152,7 @@ const app = (() => {
     normalizeFileEntry,
     listRuns,
     getRun,
+    listRunFiles,
     getRunEventsUrl,
     getHealth,
     getCronHealth,

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -299,6 +299,17 @@ pre {
   background: rgba(255, 255, 255, 0.08);
 }
 
+.download-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  background: var(--accent-strong);
+  color: #07111f;
+  font-weight: 600;
+}
+
 .notice {
   padding: 10px 14px;
   border-radius: 12px;

--- a/dashboard/run.html
+++ b/dashboard/run.html
@@ -426,32 +426,62 @@
       content.appendChild(warnSection);
     };
 
-    const renderExports = () => {
+    const renderExports = async () => {
       const listEl = ui.qs("#exports-list");
       const recommended = ui.qs("#recommended-downloads");
       listEl.innerHTML = "";
       recommended.innerHTML = "";
-      const files = (runData.files || []).map(app.normalizeFileEntry).filter(Boolean);
-      if (!files.length) {
-        listEl.appendChild(ui.el("div", { className: "notice", text: "未実装/未接続" }));
+      if (!runId) {
+        listEl.appendChild(ui.el("div", { className: "notice", text: "run idが指定されていません" }));
+        recommended.appendChild(ui.el("div", { className: "notice", text: "成果物がありません" }));
         return;
       }
-      const recommendedKeys = [
-        "package.zip",
-        "notes.zip",
-        "drafts.docx",
-        "slides.pptx",
-        "manifest.json",
+      const apiFiles = await app.apiFetchSafe(`/api/runs/${encodeURIComponent(runId)}/files`);
+      const sourceFiles = apiFiles.ok ? apiFiles.data?.files : runData.files;
+      const files = (sourceFiles || []).map(app.normalizeFileEntry).filter(Boolean);
+      if (!files.length) {
+        listEl.appendChild(ui.el("div", { className: "notice", text: "未実装/未接続" }));
+        recommended.appendChild(ui.el("div", { className: "notice", text: "成果物がありません" }));
+        return;
+      }
+      const recommendedConfigs = [
+        { label: "Download ZIP", patterns: ["package.zip", "bundle.zip", "artifacts.zip", "submission.zip", "release.zip"] },
+        { label: "Download Notes", patterns: ["notes.zip", "notes.md", "notes.txt"] },
+        { label: "Download Slides", patterns: ["slides.pptx", "slides.pdf", "slides.key"] },
+        { label: "Download Manuscript", patterns: ["drafts.docx", "draft.docx", "manuscript.docx", "paper.docx"] },
+        { label: "Download Manifest", patterns: ["manifest.json"] },
       ];
+      const normalized = files.map((file) => ({
+        ...file,
+        name: file.name || "",
+        nameLower: String(file.name || "").toLowerCase(),
+      }));
+      const recommendedLinks = [];
+      recommendedConfigs.forEach((config) => {
+        const match = normalized.find((file) =>
+          config.patterns.some((pattern) => file.nameLower.includes(pattern))
+        );
+        if (!match) return;
+        const url = app.resolveFileUrl(runId, match);
+        if (!url) return;
+        recommendedLinks.push(
+          ui.el("a", {
+            text: config.label,
+            className: "download-button",
+            attrs: { href: url, target: "_blank", rel: "noopener" },
+          })
+        );
+      });
+      if (recommendedLinks.length) {
+        recommendedLinks.forEach((link) => recommended.appendChild(link));
+      } else {
+        recommended.appendChild(ui.el("div", { className: "notice", text: "おすすめ成果物はありません" }));
+      }
       files.forEach((file) => {
         const url = app.resolveFileUrl(runId, file);
         if (!url) return;
-        const link = ui.el("a", { text: file.name, attrs: { href: url, target: "_blank" } });
+        const link = ui.el("a", { text: file.name, attrs: { href: url, target: "_blank", rel: "noopener" } });
         listEl.appendChild(link);
-        if (recommendedKeys.some((key) => file.name.includes(key))) {
-          const rec = ui.el("a", { text: `Download ${file.name}`, attrs: { href: url, target: "_blank" } });
-          recommended.appendChild(rec);
-        }
       });
     };
 
@@ -484,7 +514,7 @@
       await loadRun();
       startSse();
       renderPapers();
-      renderExports();
+      await renderExports();
       renderQa();
       renderSubmission();
 


### PR DESCRIPTION
### Motivation
- Provide a clear UI for downloading run artifacts by integrating the `/api/runs/{run_id}/files` endpoint.
- Make commonly used artifacts (zip, notes, slides, manuscript, manifest) discoverable via one-click buttons.
- Gracefully fall back to bundled `runData.files` when the API is unavailable to avoid a broken exports tab. 

### Description
- Added `listRunFiles` wrapper in `dashboard/assets/app.js` and used `app.apiFetchSafe` to query `/api/runs/{run_id}/files` in the exports view.  
- Reworked `renderExports` in `dashboard/run.html` to prefer API-sourced files, detect recommended artifacts by filename patterns, and render styled one-click download links.  
- Added `.download-button` styling to `dashboard/assets/styles.css` and improved empty/missing `runId` states and `rel="noopener"` on external links.  
- Switched `renderExports` to be `async` and `await`ed during init so recommendations load before other UI pieces depend on them.  

### Testing
- Launched a local static server for the dashboard and used a Playwright script to load `run.html?id=20251228_184723_8c1fc0d1` and capture a screenshot, which completed successfully.  
- No unit or backend tests were modified; frontend behavior falls back to preexisting `runData.files` when the files API is unreachable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695254b2bfdc8330b725d4e885d1e984)