### PR TITLE
Add scheduler CRUD controls and ops dashboard UI

### DIFF
--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -118,6 +118,26 @@ header.page-header p {
   padding: 16px;
 }
 
+.status-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.status-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
 .kpi-card h3 {
   margin: 0 0 6px;
   font-size: 0.9rem;

--- a/dashboard/ops.html
+++ b/dashboard/ops.html
@@ -19,17 +19,86 @@
   <main class="container">
     <header class="page-header">
       <h1>Ops</h1>
-      <p>運用状況やアラート、リカバリ導線をまとめる予定のページです。</p>
+      <p>運用状況やアラート、リカバリ導線をまとめるダッシュボード。</p>
     </header>
 
     <section class="panel">
       <div class="section-title">
-        <h2>Ops Dashboard</h2>
+        <h2>Health Overview</h2>
+        <button class="secondary" id="refresh-ops">更新</button>
       </div>
-      <div class="notice">未実装: 運用チェックリストや障害対応メニューをここに追加します。</div>
+      <div class="grid cols-3" id="health-grid">
+        <div class="status-card" data-key="api">
+          <div class="status-header">
+            <h3>API</h3>
+            <span class="badge" data-role="status">未取得</span>
+          </div>
+          <p class="muted" data-role="detail">未実装/未接続</p>
+        </div>
+        <div class="status-card" data-key="cron">
+          <div class="status-header">
+            <h3>Cron</h3>
+            <span class="badge" data-role="status">未取得</span>
+          </div>
+          <p class="muted" data-role="detail">未実装/未接続</p>
+        </div>
+        <div class="status-card" data-key="scheduler">
+          <div class="status-header">
+            <h3>Scheduler</h3>
+            <span class="badge" data-role="status">未取得</span>
+          </div>
+          <p class="muted" data-role="detail">未実装/未接続</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Run Metrics</h2>
+      </div>
+      <div class="grid cols-4" id="metrics-grid">
+        <div class="kpi-card">
+          <h3>Total runs</h3>
+          <div class="value" data-role="metric-total">-</div>
+        </div>
+        <div class="kpi-card">
+          <h3>Running</h3>
+          <div class="value" data-role="metric-running">-</div>
+        </div>
+        <div class="kpi-card">
+          <h3>Failed</h3>
+          <div class="value" data-role="metric-failed">-</div>
+        </div>
+        <div class="kpi-card">
+          <h3>Success</h3>
+          <div class="value" data-role="metric-success">-</div>
+        </div>
+      </div>
+      <div class="notice" id="metrics-status">データ取得中...</div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Stalled Runs</h2>
+        <span class="muted" id="stalled-summary">-</span>
+      </div>
+      <table class="table" id="stalled-table">
+        <thead>
+          <tr>
+            <th>Run ID</th>
+            <th>Status</th>
+            <th>Updated</th>
+            <th>Age</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="stalled-empty" class="notice">データがありません。</div>
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
+  <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>
     const setActiveNav = () => {
@@ -41,7 +110,144 @@
       });
     };
 
-    setActiveNav();
+    const statusTone = (value) => {
+      if (value === true) return "success";
+      if (value === false) return "danger";
+      const normalized = String(value || "").toLowerCase();
+      if (["ok", "healthy", "up", "success"].includes(normalized)) return "success";
+      if (["warn", "warning", "degraded"].includes(normalized)) return "warning";
+      if (!normalized) return "";
+      return "danger";
+    };
+
+    const setStatusCard = (key, label, detail, tone) => {
+      const card = ui.qs(`.status-card[data-key="${key}"]`);
+      if (!card) return;
+      const badge = ui.qs('[data-role="status"]', card);
+      const detailEl = ui.qs('[data-role="detail"]', card);
+      badge.textContent = label || "-";
+      badge.className = `badge ${tone || ""}`.trim();
+      detailEl.textContent = detail || "-";
+    };
+
+    const renderHealth = async () => {
+      const apiResponse = await app.apiFetchSafe("/api/health");
+      if (!apiResponse.ok) {
+        setStatusCard("api", "未接続", "API未実装/未接続", "warning");
+      } else {
+        const statusValue = apiResponse.data?.status || apiResponse.data?.state || "ok";
+        setStatusCard("api", statusValue, apiResponse.data?.message || "API is reachable", statusTone(statusValue));
+      }
+
+      const cronResponse = await app.apiFetchSafe("/api/health/cron");
+      if (!cronResponse.ok) {
+        setStatusCard("cron", "未接続", "Cron未実装/未接続", "warning");
+      } else {
+        const statusValue = cronResponse.data?.status || cronResponse.data?.state || "ok";
+        const nextRun = cronResponse.data?.next_run_at || cronResponse.data?.next_run || "-";
+        setStatusCard(
+          "cron",
+          statusValue,
+          `Next: ${nextRun}`,
+          statusTone(statusValue)
+        );
+      }
+
+      const scheduleResponse = await app.apiFetchSafe("/api/schedules");
+      if (!scheduleResponse.ok) {
+        setStatusCard("scheduler", "未接続", "Scheduler未実装/未接続", "warning");
+      } else {
+        const list = scheduleResponse.data?.schedules || [];
+        const enabledCount = list.filter((item) => item.enabled).length;
+        const detail = `Enabled: ${enabledCount}/${list.length}`;
+        const tone = list.length ? "success" : "warning";
+        setStatusCard("scheduler", list.length ? "Active" : "Empty", detail, tone);
+      }
+    };
+
+    const parseDate = (value) => {
+      if (!value) return null;
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    };
+
+    const formatAge = (ms) => {
+      if (!Number.isFinite(ms)) return "-";
+      const minutes = Math.floor(ms / 60000);
+      if (minutes < 60) return `${minutes} min`;
+      const hours = Math.floor(minutes / 60);
+      const rem = minutes % 60;
+      return `${hours}h ${rem}m`;
+    };
+
+    const renderRuns = async () => {
+      const metricsStatus = ui.qs("#metrics-status");
+      const tableBody = ui.qs("#stalled-table tbody");
+      const emptyEl = ui.qs("#stalled-empty");
+      const summaryEl = ui.qs("#stalled-summary");
+      tableBody.innerHTML = "";
+      metricsStatus.textContent = "データ取得中...";
+
+      const response = await app.apiFetchSafe("/api/runs");
+      if (!response.ok) {
+        metricsStatus.textContent = "未実装/未接続";
+        emptyEl.style.display = "block";
+        summaryEl.textContent = "-";
+        return;
+      }
+
+      const runs = response.data || [];
+      const total = runs.length;
+      const running = runs.filter((run) => run.status === "running").length;
+      const failed = runs.filter((run) => run.status === "failed").length;
+      const success = runs.filter((run) => run.status === "success").length;
+      ui.qs('[data-role="metric-total"]').textContent = ui.formatNumber(total);
+      ui.qs('[data-role="metric-running"]').textContent = ui.formatNumber(running);
+      ui.qs('[data-role="metric-failed"]').textContent = ui.formatNumber(failed);
+      ui.qs('[data-role="metric-success"]').textContent = ui.formatNumber(success);
+      metricsStatus.textContent = "";
+
+      const now = Date.now();
+      const stalledRuns = runs.filter((run) => {
+        if (run.status !== "running") return false;
+        const updated = parseDate(run.updated_at || run.last_updated || run.created_at);
+        if (!updated) return false;
+        const ageMs = now - updated.getTime();
+        return ageMs > 2 * 60 * 60 * 1000;
+      });
+
+      if (!stalledRuns.length) {
+        emptyEl.style.display = "block";
+        summaryEl.textContent = "stalled 0";
+        return;
+      }
+      emptyEl.style.display = "none";
+      summaryEl.textContent = `stalled ${stalledRuns.length}`;
+      stalledRuns.forEach((run) => {
+        const row = ui.el("tr");
+        const id = run.id || run.run_id || "-";
+        const link = ui.el("a", { text: id, attrs: { href: `run.html?id=${id}` } });
+        row.appendChild(ui.el("td", { html: link.outerHTML }));
+        row.appendChild(ui.el("td", { text: run.status || "-" }));
+        const updatedAt = parseDate(run.updated_at || run.last_updated || run.created_at);
+        row.appendChild(ui.el("td", { text: updatedAt ? updatedAt.toLocaleString() : "-" }));
+        const ageMs = updatedAt ? Date.now() - updatedAt.getTime() : null;
+        row.appendChild(ui.el("td", { text: formatAge(ageMs) }));
+        tableBody.appendChild(row);
+      });
+    };
+
+    const init = () => {
+      setActiveNav();
+      renderHealth();
+      renderRuns();
+      ui.qs("#refresh-ops").addEventListener("click", () => {
+        renderHealth();
+        renderRuns();
+      });
+    };
+
+    init();
   </script>
 </body>
 </html>

--- a/dashboard/schedule.html
+++ b/dashboard/schedule.html
@@ -101,7 +101,11 @@
           Generate submission package
         </label>
       </div>
-      <button id="create-schedule">Create</button>
+      <div class="form-row">
+        <button id="create-schedule">Create</button>
+        <button class="secondary" id="update-schedule" disabled>Save changes</button>
+        <button class="ghost" id="cancel-edit" disabled>Cancel edit</button>
+      </div>
       <div id="schedule-create-status" class="notice">未実行</div>
     </section>
 
@@ -205,6 +209,66 @@
       });
     };
 
+    const serializeForm = () => ({
+      name: ui.qs("#schedule-name").value,
+      timezone: ui.qs("#schedule-timezone").value,
+      rrule: ui.qs("#schedule-rrule").value,
+      query: {
+        keywords: ui
+          .qs("#schedule-keywords")
+          .value.split(",")
+          .map((item) => item.trim())
+          .filter(Boolean),
+        date_range_days: Number(ui.qs("#schedule-date-range").value || 30),
+        max_papers: Number(ui.qs("#schedule-max-papers").value || 50),
+        oa_only: ui.qs("#schedule-oa-only").value === "true",
+        oa_policy: ui.qs("#schedule-oa-policy").value,
+      },
+      outputs: {
+        generate_notes: ui.qs("#schedule-output-notes").checked,
+        generate_package_zip: ui.qs("#schedule-output-zip").checked,
+        generate_submission_package: ui.qs("#schedule-output-submission").checked,
+      },
+      limits: {
+        max_runtime_minutes: Number(ui.qs("#schedule-max-runtime").value || 60),
+        max_retries: Number(ui.qs("#schedule-max-retries").value || 3),
+        cooldown_minutes_after_failure: Number(ui.qs("#schedule-cooldown").value || 30),
+      },
+    });
+
+    const populateForm = (item) => {
+      ui.qs("#schedule-name").value = item?.name || "";
+      ui.qs("#schedule-timezone").value = item?.timezone || "Asia/Tokyo";
+      ui.qs("#schedule-rrule").value = item?.rrule || "";
+      ui.qs("#schedule-keywords").value = (item?.query?.keywords || []).join(", ");
+      ui.qs("#schedule-date-range").value = item?.query?.date_range_days ?? 30;
+      ui.qs("#schedule-max-papers").value = item?.query?.max_papers ?? 50;
+      ui.qs("#schedule-oa-only").value = String(item?.query?.oa_only ?? true);
+      ui.qs("#schedule-oa-policy").value = item?.query?.oa_policy || "strict";
+      ui.qs("#schedule-max-runtime").value = item?.limits?.max_runtime_minutes ?? 60;
+      ui.qs("#schedule-max-retries").value = item?.limits?.max_retries ?? 3;
+      ui.qs("#schedule-cooldown").value = item?.limits?.cooldown_minutes_after_failure ?? 30;
+      ui.qs("#schedule-output-notes").checked = item?.outputs?.generate_notes ?? true;
+      ui.qs("#schedule-output-zip").checked = item?.outputs?.generate_package_zip ?? true;
+      ui.qs("#schedule-output-submission").checked = item?.outputs?.generate_submission_package ?? false;
+    };
+
+    const setEditMode = (schedule) => {
+      const updateButton = ui.qs("#update-schedule");
+      const cancelButton = ui.qs("#cancel-edit");
+      updateButton.disabled = !schedule;
+      cancelButton.disabled = !schedule;
+      if (schedule) {
+        updateButton.dataset.scheduleId = schedule.schedule_id;
+        populateForm(schedule);
+        ui.qs("#schedule-create-status").textContent = `編集モード: ${schedule.name || schedule.schedule_id}`;
+      } else {
+        updateButton.dataset.scheduleId = "";
+        populateForm(null);
+        ui.qs("#schedule-create-status").textContent = "未実行";
+      }
+    };
+
     const renderSchedules = async () => {
       const tableBody = ui.qs("#schedule-table tbody");
       const emptyEl = ui.qs("#schedule-empty");
@@ -229,10 +293,13 @@
         const toggle = ui.el("input", { type: "checkbox" });
         toggle.checked = Boolean(item.enabled);
         toggle.addEventListener("change", async () => {
-          await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(item.schedule_id)}`, {
+          const result = await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(item.schedule_id)}`, {
             method: "PATCH",
             body: { enabled: toggle.checked },
           });
+          if (!result.ok) {
+            ui.toast("未実装/未接続", "warning");
+          }
           renderSchedules();
         });
         enabledCell.appendChild(toggle);
@@ -243,16 +310,36 @@
         const actions = ui.el("td");
         const runButton = ui.el("button", { text: "Run now" });
         runButton.addEventListener("click", async () => {
-          await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(item.schedule_id)}/run?force=true`, {
+          const result = await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(item.schedule_id)}/run?force=true`, {
             method: "POST",
           });
+          if (!result.ok) {
+            ui.toast("未実装/未接続", "warning");
+          }
           renderSchedules();
           renderHistory(item.schedule_id, item.name);
         });
+        const editButton = ui.el("button", { text: "Edit", className: "secondary" });
+        editButton.addEventListener("click", () => setEditMode(item));
         const historyButton = ui.el("button", { text: "History", className: "secondary" });
         historyButton.addEventListener("click", () => renderHistory(item.schedule_id, item.name));
+        const deleteButton = ui.el("button", { text: "Delete", className: "ghost" });
+        deleteButton.addEventListener("click", async () => {
+          if (!confirm("このスケジュールを削除しますか？")) return;
+          const result = await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(item.schedule_id)}`, {
+            method: "DELETE",
+          });
+          if (!result.ok) {
+            ui.toast("未実装/未接続", "warning");
+          }
+          setEditMode(null);
+          renderSchedules();
+          renderHistory(null);
+        });
         actions.appendChild(runButton);
+        actions.appendChild(editButton);
         actions.appendChild(historyButton);
+        actions.appendChild(deleteButton);
         row.appendChild(actions);
         tableBody.appendChild(row);
       });
@@ -270,35 +357,25 @@
         }
       });
       ui.qs("#create-schedule").addEventListener("click", async () => {
-        const payload = {
-          name: ui.qs("#schedule-name").value,
-          timezone: ui.qs("#schedule-timezone").value,
-          rrule: ui.qs("#schedule-rrule").value,
-          query: {
-            keywords: ui
-              .qs("#schedule-keywords")
-              .value.split(",")
-              .map((item) => item.trim())
-              .filter(Boolean),
-            date_range_days: Number(ui.qs("#schedule-date-range").value || 30),
-            max_papers: Number(ui.qs("#schedule-max-papers").value || 50),
-            oa_only: ui.qs("#schedule-oa-only").value === "true",
-            oa_policy: ui.qs("#schedule-oa-policy").value,
-          },
-          outputs: {
-            generate_notes: ui.qs("#schedule-output-notes").checked,
-            generate_package_zip: ui.qs("#schedule-output-zip").checked,
-            generate_submission_package: ui.qs("#schedule-output-submission").checked,
-          },
-          limits: {
-            max_runtime_minutes: Number(ui.qs("#schedule-max-runtime").value || 60),
-            max_retries: Number(ui.qs("#schedule-max-retries").value || 3),
-            cooldown_minutes_after_failure: Number(ui.qs("#schedule-cooldown").value || 30),
-          },
-        };
+        const payload = serializeForm();
         const response = await app.apiFetchSafe("/api/schedules", { method: "POST", body: payload });
-        ui.qs("#schedule-create-status").textContent = response.ok ? "作成完了" : "作成失敗";
+        ui.qs("#schedule-create-status").textContent = response.ok ? "作成完了" : "未実装/未接続";
         renderSchedules();
+      });
+      ui.qs("#update-schedule").addEventListener("click", async (event) => {
+        const scheduleId = event.currentTarget.dataset.scheduleId;
+        if (!scheduleId) return;
+        const payload = serializeForm();
+        const response = await app.apiFetchSafe(`/api/schedules/${encodeURIComponent(scheduleId)}`, {
+          method: "PATCH",
+          body: payload,
+        });
+        ui.qs("#schedule-create-status").textContent = response.ok ? "更新完了" : "未実装/未接続";
+        setEditMode(null);
+        renderSchedules();
+      });
+      ui.qs("#cancel-edit").addEventListener("click", () => {
+        setEditMode(null);
       });
     };
 


### PR DESCRIPTION
### Motivation
- Implement the scheduler UI (create/edit/delete, enable/disable, run-now, history) to satisfy the scheduler feature DoD.  
- Provide graceful feedback when the API is not configured or endpoints are not implemented.  
- Add an operations dashboard to surface system health, run metrics, and stalled runs for T12.  
- Keep the UI resilient to missing `API_BASE`/token and avoid new console errors.

### Description
- Updated `dashboard/schedule.html` to add edit/save/cancel controls, `serializeForm`, `populateForm`, `setEditMode`, and edit/delete action handlers with confirmation and safer `app.apiFetchSafe` feedback.  
- Enhanced schedule actions (enable toggle, run-now, create/update/delete) to show `ui.toast` warnings when API calls fail and to refresh schedules/history after actions.  
- Added `dashboard/ops.html` content and client logic to render health overview, run metrics, and a stalled-runs table with `renderHealth` and `renderRuns` functions and a `refresh-ops` control.  
- Extended `dashboard/assets/styles.css` with `.status-card` and `.status-header` styles and wired `assets/app.js`/`assets/storage.js` where needed.

### Testing
- Launched a local static server with `python -m http.server 8000` to exercise the pages, which started successfully.  
- Attempted a Playwright screenshot to validate the pages, but Chromium crashed in this environment so the end-to-end screenshot step failed.  
- No automated unit tests or integration tests were executed as part of this change.  
- Manual UI flows were wired to use `app.apiFetchSafe` so pages gracefully show "未実装/未接続" when the API is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695259418d10833084532dffb9c04ac0)