### PR TITLE
Add Alerts management UI and KB overview UI

### DIFF
--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -176,6 +176,12 @@ button {
   font-weight: 600;
 }
 
+button.small {
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  border-radius: 8px;
+}
+
 button.secondary {
   background: rgba(255, 255, 255, 0.1);
   color: var(--text);
@@ -305,6 +311,49 @@ pre {
   border: 1px dashed var(--border);
   color: var(--muted);
   background: rgba(255, 255, 255, 0.04);
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.toggle-slider::before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  top: 3px;
+  background: #0f1325;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.toggle input:checked + .toggle-slider {
+  background: var(--accent-strong);
+}
+
+.toggle input:checked + .toggle-slider::before {
+  transform: translateX(20px);
 }
 
 .progress-status {

--- a/dashboard/kb.html
+++ b/dashboard/kb.html
@@ -26,10 +26,44 @@
       <div class="section-title">
         <h2>KB Overview</h2>
       </div>
-      <div class="notice">未実装: KB記事のカードやタグフィルタが表示される予定です。</div>
+      <div class="grid cols-4" id="kb-status-cards"></div>
+      <div class="notice" id="kb-status-note">データ取得中...</div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Topics</h2>
+        <button class="secondary" id="kb-refresh">更新</button>
+      </div>
+      <div class="form-row">
+        <input id="kb-topic-filter" placeholder="topic 検索" />
+        <select id="kb-topic-status">
+          <option value="">Status</option>
+          <option value="active">active</option>
+          <option value="draft">draft</option>
+          <option value="archived">archived</option>
+        </select>
+      </div>
+      <div class="notice" id="kb-topics-status">データ取得中...</div>
+      <table class="table" id="kb-topics-table">
+        <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Status</th>
+            <th>Papers</th>
+            <th>Packs</th>
+            <th>Owner</th>
+            <th>Updated</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="kb-topics-empty" class="notice">データがありません。</div>
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
+  <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>
     const setActiveNav = () => {
@@ -41,7 +75,188 @@
       });
     };
 
-    setActiveNav();
+    const fallbackStatus = {
+      topics: 12,
+      papers: 482,
+      packs: 7,
+      last_sync: "2024-05-21T09:10:00Z",
+      ingestion_health: "healthy",
+    };
+
+    const fallbackTopics = [
+      {
+        id: "multimodal",
+        name: "Multimodal Retrieval",
+        status: "active",
+        papers: 74,
+        packs: 2,
+        owner: "ML Ops",
+        updated_at: "2024-05-20T11:20:00Z",
+      },
+      {
+        id: "agent-evals",
+        name: "Agent Evaluation",
+        status: "active",
+        papers: 93,
+        packs: 1,
+        owner: "Research",
+        updated_at: "2024-05-19T15:02:00Z",
+      },
+      {
+        id: "infra-roadmap",
+        name: "Infra Roadmap",
+        status: "draft",
+        papers: 18,
+        packs: 0,
+        owner: "Platform",
+        updated_at: "2024-05-18T09:44:00Z",
+      },
+      {
+        id: "policy-reg",
+        name: "Policy & Regulation",
+        status: "archived",
+        papers: 57,
+        packs: 3,
+        owner: "Compliance",
+        updated_at: "2024-05-12T20:31:00Z",
+      },
+    ];
+
+    const state = {
+      status: null,
+      topics: [],
+      apiAvailable: false,
+    };
+
+    const normalizeStatus = (data) => {
+      if (!data) return null;
+      return {
+        topics: data.topics || data.topics_count || data.topic_count || data.total_topics,
+        papers: data.papers || data.paper_count || data.total_papers,
+        packs: data.packs || data.pack_count || data.total_packs,
+        last_sync: data.last_sync || data.updated_at || data.last_ingested_at,
+        ingestion_health: data.ingestion_health || data.health || data.status,
+      };
+    };
+
+    const normalizeTopics = (data) => {
+      if (!data) return [];
+      if (Array.isArray(data)) return data;
+      return data.topics || data.items || [];
+    };
+
+    const toneForStatus = (value) => {
+      if (!value) return "";
+      const status = value.toLowerCase();
+      if (status === "active" || status === "healthy") return "success";
+      if (status === "draft" || status === "warning") return "warning";
+      if (status === "archived" || status === "error") return "danger";
+      return "";
+    };
+
+    const renderStatus = () => {
+      const cardsEl = ui.qs("#kb-status-cards");
+      const noteEl = ui.qs("#kb-status-note");
+      cardsEl.innerHTML = "";
+      if (!state.status) {
+        noteEl.textContent = "未実装/未接続";
+        return;
+      }
+      const status = state.status;
+      const cardItems = [
+        { label: "Topics", value: ui.formatNumber(status.topics) },
+        { label: "Papers", value: ui.formatNumber(status.papers) },
+        { label: "Packs", value: ui.formatNumber(status.packs) },
+        { label: "Last Sync", value: ui.formatDateTime(status.last_sync) },
+      ];
+      cardItems.forEach((item) => {
+        const card = ui.el("div", { className: "kpi-card" });
+        card.appendChild(ui.el("h3", { text: item.label }));
+        card.appendChild(ui.el("div", { className: "value", text: item.value || "-" }));
+        cardsEl.appendChild(card);
+      });
+      const healthBadge = ui.badge(status.ingestion_health || "-", toneForStatus(status.ingestion_health));
+      const healthCard = ui.el("div", { className: "kpi-card" });
+      healthCard.appendChild(ui.el("h3", { text: "Ingestion Health" }));
+      healthCard.appendChild(healthBadge);
+      cardsEl.appendChild(healthCard);
+      noteEl.textContent = state.apiAvailable ? "" : "未実装/未接続";
+    };
+
+    const renderTopics = () => {
+      const tableBody = ui.qs("#kb-topics-table tbody");
+      const emptyEl = ui.qs("#kb-topics-empty");
+      const statusEl = ui.qs("#kb-topics-status");
+      const keyword = ui.qs("#kb-topic-filter").value.trim().toLowerCase();
+      const statusFilter = ui.qs("#kb-topic-status").value;
+      tableBody.innerHTML = "";
+
+      let topics = state.topics;
+      if (keyword) {
+        topics = topics.filter((topic) =>
+          `${topic.name || topic.title || ""}`.toLowerCase().includes(keyword)
+        );
+      }
+      if (statusFilter) {
+        topics = topics.filter((topic) => (topic.status || "").toLowerCase() === statusFilter);
+      }
+      if (!topics.length) {
+        emptyEl.style.display = "block";
+        statusEl.textContent = state.apiAvailable ? "" : "未実装/未接続";
+        return;
+      }
+      emptyEl.style.display = "none";
+      statusEl.textContent = state.apiAvailable ? "" : "未実装/未接続";
+      topics.forEach((topic) => {
+        const row = ui.el("tr");
+        row.appendChild(ui.el("td", { text: topic.name || topic.title || topic.id || "-" }));
+        const statusCell = ui.el("td");
+        statusCell.appendChild(ui.badge(topic.status || "-", toneForStatus(topic.status)));
+        row.appendChild(statusCell);
+        row.appendChild(ui.el("td", { text: ui.formatNumber(topic.papers || topic.paper_count || 0) }));
+        row.appendChild(ui.el("td", { text: ui.formatNumber(topic.packs || topic.pack_count || 0) }));
+        row.appendChild(ui.el("td", { text: topic.owner || topic.owner_team || "-" }));
+        row.appendChild(ui.el("td", { text: ui.formatDateTime(topic.updated_at || topic.updated) }));
+        tableBody.appendChild(row);
+      });
+    };
+
+    const fetchKb = async () => {
+      const statusEl = ui.qs("#kb-status-note");
+      const topicsStatusEl = ui.qs("#kb-topics-status");
+      statusEl.textContent = "データ取得中...";
+      topicsStatusEl.textContent = "データ取得中...";
+      const [statusResponse, topicsResponse] = await Promise.all([
+        app.apiFetchSafe("/api/kb/status"),
+        app.apiFetchSafe("/api/kb/topics"),
+      ]);
+
+      if (!statusResponse.ok || !topicsResponse.ok) {
+        state.apiAvailable = false;
+        state.status = fallbackStatus;
+        state.topics = fallbackTopics;
+      } else {
+        state.apiAvailable = true;
+        state.status = normalizeStatus(statusResponse.data);
+        state.topics = normalizeTopics(topicsResponse.data);
+      }
+      renderStatus();
+      renderTopics();
+    };
+
+    const bindActions = () => {
+      ui.qs("#kb-refresh").addEventListener("click", fetchKb);
+      ui.qs("#kb-topic-filter").addEventListener("input", renderTopics);
+      ui.qs("#kb-topic-status").addEventListener("change", renderTopics);
+    };
+
+    const init = () => {
+      setActiveNav();
+      bindActions();
+      fetchKb();
+    };
+
+    init();
   </script>
 </body>
 </html>

--- a/dashboard/ops.html
+++ b/dashboard/ops.html
@@ -19,17 +19,55 @@
   <main class="container">
     <header class="page-header">
       <h1>Ops</h1>
-      <p>運用状況やアラート、リカバリ導線をまとめる予定のページです。</p>
+      <p>運用状況のモニタリングとアラートルールの管理をまとめます。</p>
     </header>
 
     <section class="panel">
       <div class="section-title">
-        <h2>Ops Dashboard</h2>
+        <h2>Alert Rules</h2>
+        <button class="secondary" id="refresh-alerts">更新</button>
       </div>
-      <div class="notice">未実装: 運用チェックリストや障害対応メニューをここに追加します。</div>
+      <div class="notice" id="alerts-status">データ取得中...</div>
+      <table class="table" id="alerts-table">
+        <thead>
+          <tr>
+            <th>Rule</th>
+            <th>Severity</th>
+            <th>Channels</th>
+            <th>Schedule</th>
+            <th>ON/OFF</th>
+            <th>Last Triggered</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="alerts-empty" class="notice">データがありません。</div>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Notification Test</h2>
+      </div>
+      <div class="form-row">
+        <select id="alert-test-rule"></select>
+        <select id="alert-test-channel">
+          <option value="slack">Slack</option>
+          <option value="email">Email</option>
+          <option value="pagerduty">PagerDuty</option>
+        </select>
+        <input id="alert-test-recipient" placeholder="送信先 (optional)" />
+      </div>
+      <textarea id="alert-test-message" rows="3" placeholder="テスト通知の内容"></textarea>
+      <div class="flex">
+        <button id="alert-test-send">テスト送信</button>
+      </div>
+      <div class="notice" id="alert-test-status">未実行</div>
     </section>
   </main>
 
+  <script src="assets/storage.js"></script>
+  <script src="assets/app.js"></script>
   <script src="assets/ui.js"></script>
   <script>
     const setActiveNav = () => {
@@ -41,7 +79,214 @@
       });
     };
 
-    setActiveNav();
+    const fallbackRules = [
+      {
+        id: "cpu-spike",
+        name: "CPU使用率の急上昇",
+        severity: "high",
+        channels: ["Slack", "PagerDuty"],
+        schedule: "5分",
+        enabled: true,
+        last_triggered: "2024-05-22T08:42:00Z",
+      },
+      {
+        id: "queue-lag",
+        name: "ジョブキュー遅延",
+        severity: "medium",
+        channels: ["Slack"],
+        schedule: "10分",
+        enabled: true,
+        last_triggered: "2024-05-21T19:10:00Z",
+      },
+      {
+        id: "storage-limit",
+        name: "ストレージ上限接近",
+        severity: "low",
+        channels: ["Email"],
+        schedule: "1時間",
+        enabled: false,
+        last_triggered: null,
+      },
+    ];
+
+    const state = {
+      rules: [],
+      apiAvailable: false,
+    };
+
+    const normalizeRules = (data) => {
+      if (!data) return [];
+      if (Array.isArray(data)) return data;
+      return data.rules || data.items || [];
+    };
+
+    const severityTone = (severity) => {
+      if (!severity) return "";
+      const value = severity.toLowerCase();
+      if (["critical", "high"].includes(value)) return "danger";
+      if (["medium", "warning"].includes(value)) return "warning";
+      if (["low", "info"].includes(value)) return "success";
+      return "";
+    };
+
+    const renderRules = () => {
+      const tableBody = ui.qs("#alerts-table tbody");
+      const emptyEl = ui.qs("#alerts-empty");
+      tableBody.innerHTML = "";
+      if (!state.rules.length) {
+        emptyEl.style.display = "block";
+        return;
+      }
+      emptyEl.style.display = "none";
+      state.rules.forEach((rule) => {
+        const row = ui.el("tr");
+        row.appendChild(ui.el("td", { text: rule.name || rule.id || "-" }));
+        const severityBadge = ui.badge(rule.severity || "-", severityTone(rule.severity));
+        const severityCell = ui.el("td");
+        severityCell.appendChild(severityBadge);
+        row.appendChild(severityCell);
+
+        const channelsCell = ui.el("td");
+        const channels = rule.channels || [];
+        if (channels.length === 0) {
+          channelsCell.appendChild(ui.el("span", { text: "-" }));
+        } else {
+          channels.forEach((channel) => {
+            channelsCell.appendChild(ui.badge(channel));
+          });
+        }
+        row.appendChild(channelsCell);
+
+        row.appendChild(ui.el("td", { text: rule.schedule || "-" }));
+
+        const toggleCell = ui.el("td");
+        const toggleLabel = ui.el("label", { className: "toggle" });
+        const toggleInput = ui.el("input", {
+          attrs: {
+            type: "checkbox",
+            "data-rule-id": rule.id,
+          },
+        });
+        toggleInput.checked = Boolean(rule.enabled);
+        toggleLabel.appendChild(toggleInput);
+        toggleLabel.appendChild(ui.el("span", { className: "toggle-slider" }));
+        toggleCell.appendChild(toggleLabel);
+        row.appendChild(toggleCell);
+
+        row.appendChild(ui.el("td", { text: ui.formatDateTime(rule.last_triggered) }));
+
+        const actionCell = ui.el("td");
+        const testButton = ui.el("button", {
+          text: "テスト",
+          className: "secondary small",
+          attrs: { "data-test-rule": rule.id },
+        });
+        actionCell.appendChild(testButton);
+        row.appendChild(actionCell);
+
+        tableBody.appendChild(row);
+      });
+    };
+
+    const renderRuleOptions = () => {
+      const select = ui.qs("#alert-test-rule");
+      select.innerHTML = "";
+      state.rules.forEach((rule) => {
+        select.appendChild(
+          ui.el("option", { text: rule.name || rule.id, attrs: { value: rule.id } })
+        );
+      });
+    };
+
+    const updateRuleToggle = async (ruleId, enabled) => {
+      const statusEl = ui.qs("#alerts-status");
+      const rule = state.rules.find((item) => item.id === ruleId);
+      if (rule) rule.enabled = enabled;
+      if (!state.apiAvailable) {
+        statusEl.textContent = "未実装/未接続 (ローカル反映のみ)";
+        return;
+      }
+      const response = await app.apiFetchSafe(`/api/alerts/rules/${encodeURIComponent(ruleId)}`, {
+        method: "PATCH",
+        body: { enabled },
+      });
+      if (!response.ok) {
+        statusEl.textContent = "更新に失敗しました";
+        if (rule) rule.enabled = !enabled;
+        renderRules();
+        return;
+      }
+      statusEl.textContent = "更新しました";
+    };
+
+    const sendTestNotification = async (payload) => {
+      const statusEl = ui.qs("#alert-test-status");
+      statusEl.textContent = "送信中...";
+      if (!state.apiAvailable) {
+        statusEl.textContent = "未実装/未接続";
+        ui.toast("未実装のためローカル確認のみです", "warning");
+        return;
+      }
+      const response = await app.apiFetchSafe("/api/alerts/test", { method: "POST", body: payload });
+      if (!response.ok) {
+        statusEl.textContent = "送信に失敗しました";
+        return;
+      }
+      statusEl.textContent = "送信完了";
+      ui.toast("テスト通知を送信しました", "success");
+    };
+
+    const fetchRules = async () => {
+      const statusEl = ui.qs("#alerts-status");
+      statusEl.textContent = "データ取得中...";
+      const response = await app.apiFetchSafe("/api/alerts/rules");
+      if (!response.ok) {
+        state.rules = fallbackRules;
+        state.apiAvailable = false;
+        statusEl.textContent = "未実装/未接続";
+      } else {
+        state.rules = normalizeRules(response.data);
+        state.apiAvailable = true;
+        statusEl.textContent = "";
+      }
+      renderRules();
+      renderRuleOptions();
+    };
+
+    const bindActions = () => {
+      ui.qs("#refresh-alerts").addEventListener("click", fetchRules);
+      ui.qs("#alerts-table").addEventListener("change", (event) => {
+        const target = event.target;
+        if (target.matches("input[type='checkbox'][data-rule-id]")) {
+          const ruleId = target.dataset.ruleId;
+          updateRuleToggle(ruleId, target.checked);
+        }
+      });
+      ui.qs("#alerts-table").addEventListener("click", (event) => {
+        const button = event.target.closest("button[data-test-rule]");
+        if (!button) return;
+        const ruleId = button.dataset.testRule;
+        const channel = "slack";
+        sendTestNotification({ rule_id: ruleId, channel, message: "ルール単体テスト" });
+      });
+      ui.qs("#alert-test-send").addEventListener("click", () => {
+        const payload = {
+          rule_id: ui.qs("#alert-test-rule").value,
+          channel: ui.qs("#alert-test-channel").value,
+          recipient: ui.qs("#alert-test-recipient").value.trim(),
+          message: ui.qs("#alert-test-message").value.trim() || "テスト通知",
+        };
+        sendTestNotification(payload);
+      });
+    };
+
+    const init = () => {
+      setActiveNav();
+      bindActions();
+      fetchRules();
+    };
+
+    init();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Implement Alert rules management (T13) and Knowledge Base overview (T14) pages in the dashboard.
- Provide UI controls to toggle rules and send notification tests while keeping graceful degradation when backend APIs are unavailable.
- Surface KB metrics and topic lists with client-side filtering to help inspect KB state without a backend.
- Add small reusable UI primitives for consistent appearance (`.toggle`, `button.small`).

### Description
- Added an Alerts management panel in `dashboard/ops.html` with a rules table, ON/OFF toggles, per-rule `テスト` button, and a notification test form wired to use `app.apiFetchSafe` with fallback data (`fallbackRules`).
- Added KB overview and Topics list in `dashboard/kb.html` including KPI cards, topic table, client-side filtering, API fetch logic with fallback data (`fallbackStatus`, `fallbackTopics`), and normalization helpers.
- Introduced shared style rules in `dashboard/assets/styles.css` for `button.small` and a `.toggle` switch (including `.toggle-slider`) used by the alerts UI.
- Hooked up actions and event bindings to `app` and `ui` utilities (`storage.js`, `app.js`, `ui.js`) to handle safe API calls, local state updates, and user feedback via `ui.toast`.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified pages served successfully (passed).
- Ran an automated Playwright script to open `ops.html` and `kb.html` and captured screenshots (`artifacts/ops-alerts.png`, `artifacts/kb-ui.png`) (passed).
- No unit tests or CI test suites were executed as changes are static HTML/JS/CSS additions (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952596d9cd08330b3b73651d595791c)