### PR TITLE
Run UI audit and tests before GitHub Pages deploy

### DIFF
--- a/.github/workflows/jarvis_dispatch.yml
+++ b/.github/workflows/jarvis_dispatch.yml
@@ -117,6 +117,12 @@ jobs:
           elif [ "${{ inputs.action }}" = "export_report" ]; then
             python scripts/ci_run.py --action export_report --query "dummy" --run-id "${RUN_ID}"
           fi
+
+      - name: Audit UI contract
+        run: python scripts/audit_ui_contract.py
+
+      - name: Run tests
+        run: pytest -q
       
       - name: Update status (deploy)
         if: ${{ env.CF_STATUS_URL != '' }}


### PR DESCRIPTION
### Motivation
- Prevent a broken UI or other failing artifacts from being published to the `gh-pages` branch by ensuring audits and tests run and gate deployment.
- Make test and audit failures stop the workflow so the standard action failure behavior prevents deployment.

### Description
- Added an `Audit UI contract` step running `python scripts/audit_ui_contract.py` in `.github/workflows/jarvis_dispatch.yml` before deployment.
- Added a `Run tests` step running `pytest -q` immediately after the audit so test failures will abort the job before the deploy step.
- Kept the deploy step separate so that any non-zero exit from the audit/tests will prevent `peaceiris/actions-gh-pages@v4` from executing.

### Testing
- No automated tests were executed as part of this PR because it only modifies the workflow configuration. 
- The change is limited to `.github/workflows/jarvis_dispatch.yml` and will take effect on the next workflow run where `python scripts/audit_ui_contract.py` and `pytest -q` will be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535b4e26e4833090ae8b28263bae59)