### PR TITLE
Add Artifact Contract v1 schema and examples

### DIFF
--- a/docs/contracts/artifact_contract_v1.md
+++ b/docs/contracts/artifact_contract_v1.md
@@ -1,0 +1,54 @@
+# Artifact Contract v1
+
+## Purpose
+Define the minimum manifest required to declare a run "successful" across UI/CI/Worker/Local.
+This contract fixes the semantics and shape of the artifact manifest so every surface
+validates the same output.
+
+## Manifest Location
+`schemas/artifact_manifest_v1.schema.json`
+
+## Required Fields
+### Top-level
+- `run_id` (string)
+- `created_at` (string, RFC 3339 date-time)
+- `mode` (string enum: `serverless`, `local`)
+- `query` (string)
+- `pipeline_version` (string)
+- `status` (string enum: `queued`, `running`, `success`, `failed`)
+- `artifacts` (object)
+- `quality` (object)
+- `repro` (object)
+
+### `artifacts`
+- `summary_json` (string)
+- `report_md` (string)
+- `stats_json` (string)
+- `meta_json` (string)
+- `logs_jsonl` (string)
+
+### `quality`
+- `papers_found` (integer, >= 0)
+- `papers_processed` (integer, >= 0)
+- `citations_attached` (boolean)
+- `gate_passed` (boolean)
+- `gate_reason` (string)
+
+### `repro`
+- `query_hash` (string)
+
+## Optional Fields
+### `artifacts`
+- `corpus_ref` (string)
+
+### `repro`
+- `seed` (integer)
+- `source_snapshot_ref` (string)
+
+## Success Criteria
+A run is only "successful" when:
+- `status` is `success`.
+- `quality.gate_passed` is `true`.
+
+All required fields must be present and validate against
+`schemas/artifact_manifest_v1.schema.json`.

--- a/docs/contracts/examples/manifest.failed.json
+++ b/docs/contracts/examples/manifest.failed.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "run_20250215_002",
+  "created_at": "2025-02-15T13:45:10Z",
+  "mode": "local",
+  "query": "ketogenic diet migraine randomized trials",
+  "pipeline_version": "v1.4.2",
+  "status": "failed",
+  "artifacts": {
+    "summary_json": "file:///runs/run_20250215_002/summary.json",
+    "report_md": "file:///runs/run_20250215_002/report.md",
+    "stats_json": "file:///runs/run_20250215_002/stats.json",
+    "meta_json": "file:///runs/run_20250215_002/meta.json",
+    "logs_jsonl": "file:///runs/run_20250215_002/logs.jsonl"
+  },
+  "quality": {
+    "papers_found": 3,
+    "papers_processed": 0,
+    "citations_attached": false,
+    "gate_passed": false,
+    "gate_reason": "Insufficient papers processed"
+  },
+  "repro": {
+    "query_hash": "0a6bde6d4c1c9b20ac8c4c1f7b7b34d89432a9a8b6111d12b9a1f0d551f6a53a"
+  }
+}

--- a/docs/contracts/examples/manifest.success.json
+++ b/docs/contracts/examples/manifest.success.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "run_20250215_001",
+  "created_at": "2025-02-15T12:34:56Z",
+  "mode": "serverless",
+  "query": "GLP-1 receptor agonists cardiovascular outcomes meta analysis",
+  "pipeline_version": "v1.4.2",
+  "status": "success",
+  "artifacts": {
+    "summary_json": "s3://jarvis-artifacts/run_20250215_001/summary.json",
+    "report_md": "s3://jarvis-artifacts/run_20250215_001/report.md",
+    "stats_json": "s3://jarvis-artifacts/run_20250215_001/stats.json",
+    "meta_json": "s3://jarvis-artifacts/run_20250215_001/meta.json",
+    "logs_jsonl": "s3://jarvis-artifacts/run_20250215_001/logs.jsonl",
+    "corpus_ref": "snapshot:corpus_2025_02_10"
+  },
+  "quality": {
+    "papers_found": 42,
+    "papers_processed": 36,
+    "citations_attached": true,
+    "gate_passed": true,
+    "gate_reason": "Quality gate passed"
+  },
+  "repro": {
+    "seed": 1337,
+    "query_hash": "b3bb0e85a7c9d0d7a2c02c49b1b0e6a3b574a918a81f3dd3b0d7b3a61e937a1a",
+    "source_snapshot_ref": "snapshot:papers_2025_02_10"
+  }
+}

--- a/schemas/artifact_manifest_v1.schema.json
+++ b/schemas/artifact_manifest_v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jarvis-research-os/schemas/artifact_manifest_v1.schema.json",
+  "title": "Artifact Manifest v1",
+  "description": "Contract for artifact manifests that define run success and reproducibility.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "run_id",
+    "created_at",
+    "mode",
+    "query",
+    "pipeline_version",
+    "status",
+    "artifacts",
+    "quality",
+    "repro"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "serverless",
+        "local"
+      ]
+    },
+    "query": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pipeline_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "queued",
+        "running",
+        "success",
+        "failed"
+      ]
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary_json",
+        "report_md",
+        "stats_json",
+        "meta_json",
+        "logs_jsonl"
+      ],
+      "properties": {
+        "summary_json": {
+          "type": "string",
+          "minLength": 1
+        },
+        "report_md": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stats_json": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta_json": {
+          "type": "string",
+          "minLength": 1
+        },
+        "logs_jsonl": {
+          "type": "string",
+          "minLength": 1
+        },
+        "corpus_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "papers_found",
+        "papers_processed",
+        "citations_attached",
+        "gate_passed",
+        "gate_reason"
+      ],
+      "properties": {
+        "papers_found": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "papers_processed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "citations_attached": {
+          "type": "boolean"
+        },
+        "gate_passed": {
+          "type": "boolean"
+        },
+        "gate_reason": {
+          "type": "string"
+        }
+      }
+    },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "query_hash"
+      ],
+      "properties": {
+        "seed": {
+          "type": "integer"
+        },
+        "query_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_snapshot_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Establish a single, machine-checkable contract for declaring a run "successful" across UI/CI/Worker/Local surfaces.
- Fix required fields and success criteria to improve reproducibility and consistency of pipeline outputs.
- Provide a strict JSON Schema so CI and tools can validate manifests programmatically.
- Ship canonical example manifests to demonstrate both success and failure cases.

### Description
- Add `docs/contracts/artifact_contract_v1.md` that enumerates required and optional fields and defines success criteria.
- Add `schemas/artifact_manifest_v1.schema.json` (JSON Schema draft-07) that enforces required top-level properties, field types, enums, and `additionalProperties: false` for strict validation.
- Add example manifests `docs/contracts/examples/manifest.success.json` and `docs/contracts/examples/manifest.failed.json` demonstrating valid success and failure payloads.
- The schema and docs codify fields such as `artifacts`, `quality`, and `repro` and constraints like `status` enum and date-time formatting for `created_at`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695361e6f3a88330a59bb1feadaa30a3)