### PR TITLE
Emit Artifact Contract v1 manifests for CI runs and make dashboard manifest-driven

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -493,7 +493,7 @@
             </div>
             <div class="kpi-card">
                 <div class="kpi-value" id="kpi-contract">-</div>
-                <div class="kpi-label">Contract Valid</div>
+                <div class="kpi-label">Gate Passed</div>
             </div>
             <div class="kpi-card">
                 <div class="kpi-value" id="kpi-papers">-</div>
@@ -685,24 +685,20 @@
         function updateKPIs() {
             const total = runs.length;
             const successful = runs.filter(r => r.status === 'success').length;
-            const contractValid = runs.filter(r => r.contract_valid).length;
-            const avgCoverage = runs.length > 0
-                ? runs.reduce((sum, r) => sum + (r.metrics?.evidence_coverage || 0), 0) / runs.length
-                : 0;
+            const gatePassed = runs.filter(r => r.gate_passed).length;
 
-            // Total papers/claims from all runs
-            let totalPapers = 0, totalClaims = 0;
+            // Total papers from all runs
+            let totalPapers = 0;
             runs.forEach(r => {
-                totalPapers += r.metrics?.paper_count || 0;
-                totalClaims += r.metrics?.claim_count || 0;
+                totalPapers += r.papers_found || 0;
             });
 
             document.getElementById('kpi-runs').textContent = total;
             document.getElementById('kpi-success').textContent = total > 0 ? `${((successful / total) * 100).toFixed(0)}%` : '-';
-            document.getElementById('kpi-coverage').textContent = `${(avgCoverage * 100).toFixed(1)}%`;
-            document.getElementById('kpi-contract').textContent = `${contractValid}/${total}`;
+            document.getElementById('kpi-coverage').textContent = '-';
+            document.getElementById('kpi-contract').textContent = `${gatePassed}/${total}`;
             document.getElementById('kpi-papers').textContent = totalPapers || '-';
-            document.getElementById('kpi-claims').textContent = totalClaims || '-';
+            document.getElementById('kpi-claims').textContent = '-';
 
             document.getElementById('success-bar').style.width = total > 0 ? `${(successful / total) * 100}%` : '0%';
         }
@@ -765,13 +761,13 @@
             let html = '<table class="data-table"><thead><tr><th>Run ID</th><th>Timestamp</th><th>Status</th><th>Gate</th><th>Coverage</th></tr></thead><tbody>';
             runs.slice(0, 10).forEach(run => {
                 const statusClass = run.status === 'success' ? 'badge-success' : run.status === 'failed' ? 'badge-danger' : 'badge-warning';
-                const coverage = ((run.metrics?.evidence_coverage || 0) * 100).toFixed(1);
+                const papersFound = run.papers_found ?? '-';
                 html += `<tr onclick="showRunDetail('${run.run_id}')">
                     <td>${run.run_id?.substring(0, 16) || '-'}...</td>
-                    <td>${run.timestamp || '-'}</td>
+                    <td>${run.created_at || '-'}</td>
                     <td><span class="badge ${statusClass}">${run.status || 'unknown'}</span></td>
                     <td>${run.gate_passed ? '✅' : '❌'}</td>
-                    <td>${coverage}%</td>
+                    <td>${papersFound}</td>
                 </tr>`;
             });
             html += '</tbody></table>';
@@ -786,17 +782,16 @@
                 return;
             }
 
-            let html = '<table class="data-table"><thead><tr><th>Run ID</th><th>Timestamp</th><th>Status</th><th>Gate</th><th>Contract</th><th>Coverage</th></tr></thead><tbody>';
+            let html = '<table class="data-table"><thead><tr><th>Run ID</th><th>Timestamp</th><th>Status</th><th>Gate</th><th>Papers</th></tr></thead><tbody>';
             runs.forEach(run => {
                 const statusClass = run.status === 'success' ? 'badge-success' : run.status === 'failed' ? 'badge-danger' : 'badge-warning';
-                const coverage = ((run.metrics?.evidence_coverage || 0) * 100).toFixed(1);
+                const papersFound = run.papers_found ?? '-';
                 html += `<tr onclick="showRunDetail('${run.run_id}')">
                     <td>${run.run_id?.substring(0, 20) || '-'}...</td>
-                    <td>${run.timestamp || '-'}</td>
+                    <td>${run.created_at || '-'}</td>
                     <td><span class="badge ${statusClass}">${run.status || 'unknown'}</span></td>
                     <td>${run.gate_passed ? '✅' : '❌'}</td>
-                    <td>${run.contract_valid ? '10/10' : 'Missing'}</td>
-                    <td>${coverage}%</td>
+                    <td>${papersFound}</td>
                 </tr>`;
             });
             html += '</tbody></table>';
@@ -1037,21 +1032,23 @@
                 let meta = null;
                 const errors = [];
 
-                if (localServerAvailable) {
+                let manifest = null;
+                const manifestRes = await fetch(`runs/${runId}/manifest.json`, { cache: 'no-store' });
+                if (manifestRes.ok) {
+                    manifest = await manifestRes.json();
+                } else if (localServerAvailable) {
                     const res = await fetch(`${API_BASE}/api/runs/${runId}`);
                     if (!res.ok) {
-                        throw new Error(`summary 取得失敗 (${res.status})`);
+                        throw new Error(`manifest 取得失敗 (${manifestRes.status})`);
                     }
                     run = await res.json();
                     report = run.report || null;
                 } else {
-                    const summaryRes = await fetch(`runs/${runId}/summary.json`, { cache: 'no-store' });
-                    if (!summaryRes.ok) {
-                        throw new Error(`summary 取得失敗 (${summaryRes.status})`);
-                    }
-                    const summary = await summaryRes.json();
+                    throw new Error(`manifest 取得失敗 (${manifestRes.status})`);
+                }
 
-                    const reportPath = summary?.artifacts?.report_md;
+                if (manifest) {
+                    const reportPath = manifest?.artifacts?.report_md;
                     if (reportPath) {
                         try {
                             const reportRes = await fetch(reportPath, { cache: 'no-store' });
@@ -1064,7 +1061,7 @@
                         }
                     }
 
-                    const metaPath = summary?.artifacts?.meta_json;
+                    const metaPath = manifest?.artifacts?.meta_json;
                     if (metaPath) {
                         try {
                             const metaRes = await fetch(metaPath, { cache: 'no-store' });
@@ -1078,20 +1075,26 @@
                     }
 
                     run = {
-                        status: summary.status,
-                        gate_passed: summary.gate_passed ?? null,
-                        contract_valid: summary.contract_valid ?? null,
-                        timestamp: summary.finished_at || summary.started_at || '-',
+                        status: manifest.status,
+                        gate_passed: manifest?.quality?.gate_passed ?? null,
+                        contract_valid: null,
+                        timestamp: manifest.created_at || '-',
                         metrics: {
-                            papers: summary.papers,
-                            claims: summary.claims,
-                            evidence: summary.evidence
+                            papers_found: manifest?.quality?.papers_found ?? 0,
+                            papers_processed: manifest?.quality?.papers_processed ?? 0,
+                            citations_attached: manifest?.quality?.citations_attached ?? false
                         },
-                        files: {}
+                        artifacts: manifest?.artifacts || {}
                     };
                 }
 
                 const normalizedStatus = normalizeStatus(run.status);
+                const artifactRows = Object.entries(run.artifacts || {}).map(([name, path]) => {
+                    if (!path) {
+                        return `<tr><td>${escapeHtml(name)}</td><td>-</td></tr>`;
+                    }
+                    return `<tr><td>${escapeHtml(name)}</td><td><a href="${escapeHtml(path)}" target="_blank" rel="noopener">${escapeHtml(path)}</a></td></tr>`;
+                }).join('');
 
                 body.innerHTML = `
                     <h2>Run: ${runId}</h2>
@@ -1109,11 +1112,9 @@
                 ).join('')}
                     </table>
 
-                    <h3>📁 Files</h3>
+                    <h3>📁 Artifacts</h3>
                     <table class="data-table" style="margin: 20px 0;">
-                        ${Object.entries(run.files || {}).map(([name, info]) =>
-                    `<tr><td>${info.exists ? '✅' : '❌'} ${name}</td><td>${info.size} bytes</td></tr>`
-                ).join('')}
+                        ${artifactRows || '<tr><td colspan="2">No artifacts</td></tr>'}
                     </table>
 
                     ${report ? `<h3>📝 Report</h3><pre style="max-height: 300px; overflow: auto; background: var(--bg-primary); padding: 15px; border-radius: 8px; white-space: pre-wrap;">${escapeHtml(report)}</pre>` : ''}

--- a/scripts/build_runs_index.py
+++ b/scripts/build_runs_index.py
@@ -1,7 +1,7 @@
 """Build Runs Index - runs一覧を生成
 
 このスクリプトは ci_run.py から呼び出され、以下を行います:
-1. public/runs/*/summary.jsonを走査
+1. public/runs/*/manifest.jsonを走査
 2. 新しい順にソート
 3. 最大50件でカット（Pages容量対策）
 4. public/runs/index.jsonに出力
@@ -12,69 +12,82 @@ from datetime import datetime
 from pathlib import Path
 
 
-def load_summaries(runs_dir):
-    """すべてのsummary.jsonを読み込む"""
-    summaries = []
+def load_manifests(runs_dir):
+    """すべてのmanifest.jsonを読み込む"""
+    manifests = []
     
     if not runs_dir.exists():
         print(f"[build_runs_index] runs directory not found: {runs_dir}", file=sys.stderr)
-        return summaries
+        return manifests
     
     for run_path in runs_dir.iterdir():
         if not run_path.is_dir():
             continue
         
-        summary_file = run_path / "summary.json"
-        if not summary_file.exists():
+        manifest_file = run_path / "manifest.json"
+        if not manifest_file.exists():
             continue
         
         try:
-            with open(summary_file, "r", encoding="utf-8") as f:
-                summary = json.load(f)
-                summaries.append(summary)
+            with open(manifest_file, "r", encoding="utf-8") as f:
+                manifest = json.load(f)
+                manifests.append(manifest)
         except Exception as e:
-            print(f"[build_runs_index] WARNING: Failed to load {summary_file}: {e}", file=sys.stderr)
+            print(f"[build_runs_index] WARNING: Failed to load {manifest_file}: {e}", file=sys.stderr)
             continue
     
-    return summaries
+    return manifests
 
 
-def sort_summaries(summaries):
-    """summaryを新しい順にソート"""
-    def get_timestamp(summary):
-        # started_at or finished_at でソート
-        ts = summary.get("finished_at") or summary.get("started_at") or ""
+def sort_manifests(manifests):
+    """manifestを新しい順にソート"""
+    def get_timestamp(manifest):
+        ts = manifest.get("created_at") or ""
         try:
             return datetime.fromisoformat(ts.replace("Z", "+00:00"))
         except Exception:
             return datetime.min
     
-    return sorted(summaries, key=get_timestamp, reverse=True)
+    return sorted(manifests, key=get_timestamp, reverse=True)
+
+
+def extract_index_entry(manifest):
+    """manifestからindex用の最小情報を抽出"""
+    quality = manifest.get("quality", {})
+    return {
+        "run_id": manifest.get("run_id"),
+        "status": manifest.get("status"),
+        "created_at": manifest.get("created_at"),
+        "papers_found": quality.get("papers_found"),
+        "gate_passed": quality.get("gate_passed"),
+    }
 
 
 def main():
     runs_dir = Path("public") / "runs"
     index_file = runs_dir / "index.json"
     
-    # summary.jsonを読み込み
-    summaries = load_summaries(runs_dir)
-    print(f"[build_runs_index] Found {len(summaries)} runs")
+    # manifest.jsonを読み込み
+    manifests = load_manifests(runs_dir)
+    print(f"[build_runs_index] Found {len(manifests)} runs")
     
     # ソート
-    summaries = sort_summaries(summaries)
+    manifests = sort_manifests(manifests)
     
     # 最大50件でカット（Pages容量制限対策）
     MAX_RUNS = 50
-    if len(summaries) > MAX_RUNS:
+    if len(manifests) > MAX_RUNS:
         print(f"[build_runs_index] Truncating to {MAX_RUNS} runs (capacity limit)")
-        summaries = summaries[:MAX_RUNS]
+        manifests = manifests[:MAX_RUNS]
+
+    index_entries = [extract_index_entry(manifest) for manifest in manifests]
     
     # index.jsonに出力
     runs_dir.mkdir(parents=True, exist_ok=True)
     with open(index_file, "w", encoding="utf-8") as f:
-        json.dump(summaries, f, indent=2, ensure_ascii=False)
+        json.dump(index_entries, f, indent=2, ensure_ascii=False)
     
-    print(f"[build_runs_index] Wrote {len(summaries)} runs to {index_file}")
+    print(f"[build_runs_index] Wrote {len(index_entries)} runs to {index_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Ensure the UI can rely on a single manifest artifact (`manifest.json`) instead of ad-hoc summary files so Serverless/Local differences are absorbed. 
- Make CI runs produce a stable Artifact Contract v1 manifest so downstream surfaces (UI/CI/Workers/Local) share the same success semantics. 
- Reduce the amount of data the public index needs to carry by extracting minimal run info from the manifest. 
- Make Run detail view load artifacts/links via manifest paths to centralize artifact discovery.

### Description

- Updated `scripts/ci_run.py` to always emit `public/runs/<run_id>/manifest.json` (Artifact Contract v1) by adding `generate_manifest`, `detect_mode`, `hash_query`, and helper functions to create placeholder artifacts when missing. 
- Manifest contents include top-level fields (`run_id`, `created_at`, `mode`, `query`, `pipeline_version`, `status`), `artifacts` paths, `quality` metrics (`papers_found`, `papers_processed`, `gate_passed`, etc.) and `repro.query_hash` to satisfy the schema in `schemas/artifact_manifest_v1.schema.json`. 
- Rewrote `scripts/build_runs_index.py` to scan `public/runs/*/manifest.json`, sort by `created_at`, and produce `public/runs/index.json` containing minimal entries (`run_id`, `status`, `created_at`, `papers_found`, `gate_passed`). 
- Changed `public/index.html` to be manifest-first: KPIs and run lists use manifest fields (`gate_passed`, `papers_found`, `created_at`) and the Run detail modal fetches `manifest.json` and loads artifact links (report/meta/stats) via manifest paths.

### Testing

- Performed a local smoke test by serving `public/` with `python -m http.server 8000 --directory public` and running a Playwright script to load the dashboard and capture a screenshot, which completed successfully and produced `artifacts/manifest-dashboard.png`.
- `scripts/build_runs_index.py` was exercised locally as part of code inspection and is adapted to the new manifest shape (no automated unit tests were executed on it in this run).
- No full CI/unit test suite was run as part of this change; static/manual checks and a browser render smoke test were used to validate the UI integration.
- If desired, follow-up runs should execute the full test matrix and a real CI run to validate manifest generation during actual pipeline execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695362c5de9083309ba851eb0cb1b3cb)