### PR TITLE
Add Quality Gate v1 evaluator and enforce in CI

### DIFF
--- a/docs/contracts/quality_gate_v1.md
+++ b/docs/contracts/quality_gate_v1.md
@@ -1,0 +1,35 @@
+# Quality Gate v1
+
+## 目的
+"空っぽの成功"を禁止し、CIの成果物が最低品質を満たしているかを機械的に判定する。
+
+## 入力
+次の成果物から評価する。
+
+- `summary.json`
+- `stats.json`
+- `report.md`
+- `warnings.jsonl` (任意)
+
+## 判定基準 (v1)
+
+| 項目 | 判定 | 備考 |
+| --- | --- | --- |
+| papers_found | `>= 1` | `stats.json` の `meta` を優先し、なければ `summary.json` の `papers` を使用 |
+| report.md | 存在する | `report.md` が生成されていること |
+| citations_attached | `true` | `report.md` 内に引用の痕跡 (例: `[1]` または `http`) があること |
+
+## 出力
+
+Quality Gate v1 は以下を返す。
+
+- `gate_passed` (boolean)
+- `gate_reason` (string)
+- `papers_found` (integer)
+- `papers_processed` (integer)
+- `citations_attached` (boolean)
+
+## 運用ルール
+
+- `gate_passed` が `false` の場合、CIの `status` は必ず `failed` に落とす。
+- `gate_passed` が `true` であっても、`status` が `failed` の場合は成功とは見なさない。

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Quality Gate v1 evaluator."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+CITATION_PATTERN = re.compile(r"\[[0-9]+\]")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return {}
+
+
+def detect_citations_attached(report_path: Path) -> bool:
+    if not report_path.exists():
+        return False
+    try:
+        content = report_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        content = report_path.read_text(encoding="utf-8", errors="ignore")
+    if not content.strip():
+        return False
+    return bool(CITATION_PATTERN.search(content) or "http" in content)
+
+
+def count_warnings(log_path: Path) -> int:
+    if not log_path.exists():
+        return 0
+    try:
+        with log_path.open("r", encoding="utf-8") as f:
+            return sum(1 for line in f if line.strip())
+    except OSError:
+        return 0
+
+
+def evaluate_quality_gate(run_dir: Path) -> dict[str, Any]:
+    summary = load_json(run_dir / "summary.json")
+    stats = load_json(run_dir / "stats.json")
+    warnings_path = run_dir / "warnings.jsonl"
+    report_path = run_dir / "report.md"
+
+    papers_found = stats.get("meta")
+    if papers_found is None:
+        papers_found = summary.get("papers", 0)
+    papers_found = int(papers_found or 0)
+
+    papers_processed = int(stats.get("chunks", 0) or 0)
+    report_exists = report_path.exists()
+    citations_attached = detect_citations_attached(report_path)
+
+    reasons = []
+    if papers_found < 1:
+        reasons.append("No papers found")
+    if not report_exists:
+        reasons.append("report.md missing")
+    if not citations_attached:
+        reasons.append("Citations not attached")
+
+    gate_passed = len(reasons) == 0
+    gate_reason = "Gate passed" if gate_passed else "; ".join(reasons)
+
+    return {
+        "gate_passed": gate_passed,
+        "gate_reason": gate_reason,
+        "papers_found": papers_found,
+        "papers_processed": papers_processed,
+        "citations_attached": citations_attached,
+        "report_exists": report_exists,
+        "warnings_count": count_warnings(warnings_path),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate Quality Gate v1")
+    parser.add_argument("--run-dir", required=True, help="Path to run directory")
+    parser.add_argument("--json", action="store_true", help="Emit JSON to stdout")
+    args = parser.parse_args()
+
+    result = evaluate_quality_gate(Path(args.run_dir))
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        status = "PASS" if result["gate_passed"] else "FAIL"
+        print(f"Quality Gate v1: {status} - {result['gate_reason']}")
+
+    return 0 if result["gate_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Prevent "empty success" by ensuring CI-run artifacts meet a minimum quality bar before a run can be considered successful.  
- Encode the Quality Gate v1 criteria (papers found, `report.md` present, citations attached) as machine-checkable logic.  
- Make CI deterministically fail runs that pass the pipeline but do not satisfy the quality contract.

### Description
- Add `scripts/quality_gate.py` which implements `evaluate_quality_gate(run_dir)` and returns `gate_passed`, `gate_reason`, `papers_found`, `papers_processed`, and `citations_attached` according to the v1 criteria.  
- Add `docs/contracts/quality_gate_v1.md` documenting the gate inputs, checks (`papers_found >= 1`, `report.md` exists, citations present), outputs, and operational rule that failing the gate forces CI `status` to `failed`.  
- Update `scripts/ci_run.py` to dynamically load and call the gate via `evaluate_quality_gate`, append a `quality_gate_failed` warning when applicable, force `status = "failed"` if the gate fails, and incorporate `quality` into `summary.json` and `manifest.json`.  
- Adjust `generate_summary` and `generate_manifest` signatures to accept and surface the computed `quality` values in artifacts.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695364508fd08330a3688611580c5931)