### PR TITLE
Implement run retention pruning and add retention policy docs

### DIFF
--- a/docs/ops/retention_policy.md
+++ b/docs/ops/retention_policy.md
@@ -1,0 +1,32 @@
+# Run Retention Policy
+
+## 目的
+
+`public/runs/` に生成される実行結果が増え続けると、GitHubリポジトリが肥大化し続けて運用が破綻します。
+このポリシーは長期運用でもリポジトリサイズが指数的に増えないようにするためのものです。
+
+## 保持方針（デフォルト）
+
+`public/runs/<run_id>/` を対象に、次のどちらか（両方指定時は厳しい方）で保持します。
+
+- `KEEP_DAYS=14`
+- `KEEP_LAST=50`
+
+`KEEP_DAYS` と `KEEP_LAST` の両方が指定されている場合は、**両方を満たすもののみ保持**します。
+つまり「直近の日数内であり、かつ最新N件以内」の条件を満たさない run は削除対象になります。
+
+## アーカイブと削除
+
+削除対象の run はディレクトリごと削除されます。
+削除前に `manifest.json` から最小限の情報を取り出し、
+`public/runs/archive_index.jsonl` に追記して監査可能にします。
+
+## 重要: 復元不可
+
+`public/runs/<run_id>/` の削除は **復元不可** です。
+削除後は `archive_index.jsonl` に残された情報のみが唯一の記録となります。
+
+## 運用スクリプト
+
+- 実行: `scripts/prune_runs.py`
+- 影響: 削除後に `scripts/build_runs_index.py` を実行して `public/runs/index.json` を再生成すること。

--- a/scripts/prune_runs.py
+++ b/scripts/prune_runs.py
@@ -1,0 +1,159 @@
+"""Prune old run directories under public/runs.
+
+Retention policy defaults:
+- KEEP_DAYS=14
+- KEEP_LAST=50
+
+If both are specified, the stricter retention applies (must satisfy both).
+Before deleting a run directory, append minimal manifest info to
+public/runs/archive_index.jsonl for auditability.
+"""
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_KEEP_DAYS = 14
+DEFAULT_KEEP_LAST = 50
+
+
+@dataclass
+class RunInfo:
+    run_id: str
+    path: Path
+    created_at: Optional[datetime]
+    sort_key: datetime
+    manifest: dict
+
+
+def parse_iso_datetime(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def load_manifest(run_path: Path) -> dict:
+    manifest_file = run_path / "manifest.json"
+    if not manifest_file.exists():
+        return {}
+    try:
+        with manifest_file.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:
+        print(f"[prune_runs] WARNING: Failed to load {manifest_file}: {exc}", file=sys.stderr)
+        return {}
+
+
+def build_run_info(run_path: Path) -> RunInfo:
+    manifest = load_manifest(run_path)
+    run_id = manifest.get("run_id") or run_path.name
+    created_at = parse_iso_datetime(manifest.get("created_at", ""))
+
+    if created_at is None:
+        stat = run_path.stat()
+        created_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+
+    return RunInfo(
+        run_id=run_id,
+        path=run_path,
+        created_at=created_at,
+        sort_key=created_at,
+        manifest=manifest,
+    )
+
+
+def minimal_archive_entry(run_info: RunInfo, archived_at: datetime, reason: str) -> dict:
+    quality = run_info.manifest.get("quality", {}) if run_info.manifest else {}
+    return {
+        "run_id": run_info.run_id,
+        "created_at": run_info.manifest.get("created_at") or run_info.created_at.isoformat(),
+        "status": run_info.manifest.get("status"),
+        "papers_found": quality.get("papers_found"),
+        "gate_passed": quality.get("gate_passed"),
+        "archived_at": archived_at.isoformat(),
+        "reason": reason,
+    }
+
+
+def append_jsonl(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
+
+def parse_int(value: Optional[str], default: int) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        print(f"[prune_runs] WARNING: invalid int value '{value}', using default {default}")
+        return default
+
+
+def main() -> int:
+    keep_days = parse_int(os.environ.get("KEEP_DAYS"), DEFAULT_KEEP_DAYS)
+    keep_last = parse_int(os.environ.get("KEEP_LAST"), DEFAULT_KEEP_LAST)
+
+    runs_dir = Path("public") / "runs"
+    if not runs_dir.exists():
+        print(f"[prune_runs] runs directory not found: {runs_dir}")
+        return 0
+
+    run_paths = [p for p in runs_dir.iterdir() if p.is_dir()]
+    run_infos = [build_run_info(run_path) for run_path in run_paths]
+
+    if not run_infos:
+        print("[prune_runs] no runs to prune")
+        return 0
+
+    run_infos.sort(key=lambda item: item.sort_key, reverse=True)
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=keep_days)
+
+    keep_by_days = {info.run_id for info in run_infos if info.created_at >= cutoff}
+    keep_by_last = {info.run_id for info in run_infos[:keep_last]}
+
+    apply_days = keep_days is not None
+    apply_last = keep_last is not None
+
+    if apply_days and apply_last:
+        keep_ids = keep_by_days & keep_by_last
+        reason = f"keep_days={keep_days}, keep_last={keep_last}"
+    elif apply_days:
+        keep_ids = keep_by_days
+        reason = f"keep_days={keep_days}"
+    else:
+        keep_ids = keep_by_last
+        reason = f"keep_last={keep_last}"
+
+    archive_path = runs_dir / "archive_index.jsonl"
+    archived_at = datetime.now(timezone.utc)
+
+    delete_infos = [info for info in run_infos if info.run_id not in keep_ids]
+
+    print(
+        "[prune_runs] total=%d keep=%d delete=%d (%s)"
+        % (len(run_infos), len(keep_ids), len(delete_infos), reason)
+    )
+
+    for info in delete_infos:
+        entry = minimal_archive_entry(info, archived_at=archived_at, reason=reason)
+        append_jsonl(archive_path, entry)
+        shutil.rmtree(info.path)
+        print(f"[prune_runs] deleted {info.path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Prevent uncontrolled growth of `public/runs/` which would bloat the GitHub repository and break long-term operation.  
- Ensure deleted runs are auditable by recording minimal manifest metadata before removal.  
- Provide a simple, environment-configurable retention strategy to limit storage footprint.  
- Make clear that deletion of `public/runs/<run_id>/` is irreversible and must be treated as destructive.

### Description

- Add `scripts/prune_runs.py` which prunes `public/runs/<run_id>/` using `KEEP_DAYS` (default 14) and `KEEP_LAST` (default 50) and applies the stricter condition when both are present.  
- Before deleting a run directory the script appends a minimal manifest entry to `public/runs/archive_index.jsonl` for auditability and then removes the run directory.  
- The pruning logic determines `created_at` from `manifest.json` when available and falls back to filesystem timestamps when not.  
- Add `docs/ops/retention_policy.md` documenting the retention rules, the irreversible nature of deletion, and the recommendation to run `scripts/build_runs_index.py` after pruning to regenerate `public/runs/index.json`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695366d97df48330bf38b552d7120056)