### PR TITLE
Add serverless search index builder and client-side search with pagination

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -314,6 +314,38 @@
             font-size: 0.9em;
         }
 
+        .search-pagination {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-top: 15px;
+            flex-wrap: wrap;
+        }
+
+        .search-pagination button {
+            padding: 8px 14px;
+            border-radius: 8px;
+            background: var(--bg-secondary);
+            color: var(--text-primary);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            cursor: pointer;
+        }
+
+        .search-pagination button:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .search-meta-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+            color: var(--text-secondary);
+            font-size: 0.9em;
+            margin-top: 6px;
+        }
+
         .highlight {
             background: rgba(0, 212, 255, 0.3);
             padding: 2px 4px;
@@ -464,7 +496,7 @@
         <div class="nav-tabs">
             <div class="nav-tab active" onclick="showTab('overview')">📊 概要</div>
             <div class="nav-tab" onclick="showTab('new-query')">🔍 新規クエリ</div>
-            <div class="nav-tab local-only-tab" style="display:none;" onclick="showTab('search')">📑 検索</div>
+            <div class="nav-tab" onclick="showTab('search')">📑 検索</div>
             <div class="nav-tab local-only-tab" style="display:none;" onclick="showTab('schedule')">🗓️ スケジューラ</div>
             <div class="nav-tab local-only-tab" style="display:none;" onclick="showTab('upload')">📁 アップロード</div>
             <div class="nav-tab" onclick="showTab('runs')">📋 実行履歴</div>
@@ -581,15 +613,28 @@
         <!-- Tab: Search -->
         <div id="tab-search" class="tab-content">
             <div class="section">
-                <h2>📑 コーパス検索（BM25）</h2>
-                <p style="color: var(--warning); margin-bottom: 12px;">⚠️ Local APIが必要です（Serverlessでは利用不可）</p>
+                <h2>📑 コーパス検索（Serverless）</h2>
+                <p style="color: var(--text-secondary); margin-bottom: 12px;">public/search/index.json を読み込み、ブラウザ内で検索します。</p>
                 <div class="form-row">
                     <div class="form-group" style="flex: 4;">
                         <input type="text" id="search-input" placeholder="検索キーワード...">
                     </div>
+                    <div class="form-group" style="flex: 1;">
+                        <select id="search-page-size">
+                            <option value="10">10件/頁</option>
+                            <option value="20" selected>20件/頁</option>
+                            <option value="50">50件/頁</option>
+                        </select>
+                    </div>
                     <button class="btn btn-primary" onclick="searchCorpus()">検索</button>
                 </div>
+                <div id="search-summary" class="search-meta-row"></div>
                 <div id="search-results" class="search-results"></div>
+                <div class="search-pagination" id="search-pagination">
+                    <button id="search-prev" onclick="changeSearchPage(-1)">◀ 前へ</button>
+                    <span id="search-page-info">0 / 0</span>
+                    <button id="search-next" onclick="changeSearchPage(1)">次へ ▶</button>
+                </div>
             </div>
         </div>
 
@@ -651,6 +696,10 @@
         let runs = [];
         let currentTab = 'overview';
         let turnstileToken = null;
+        let searchIndex = null;
+        let searchResults = [];
+        let searchPage = 1;
+        let searchPageSize = 20;
 
         // === Check Local Server Availability ===
         async function checkLocalServer() {
@@ -931,35 +980,170 @@
             }, interval);
         }
 
-        // === Search Corpus ===
+        // === Search Corpus (Serverless) ===
+        async function loadSearchIndex() {
+            if (searchIndex) return searchIndex;
+            const res = await fetch('search/index.json', { cache: 'no-store' });
+            if (!res.ok) {
+                throw new Error('search/index.json が見つかりません');
+            }
+            const data = await res.json();
+            const docs = Array.isArray(data.docs) ? data.docs : [];
+
+            const stopwords = new Set([
+                'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'has', 'he', 'in', 'is', 'it', 'its',
+                'of', 'on', 'that', 'the', 'to', 'was', 'were', 'will', 'with', 'this', 'these', 'those', 'we', 'you',
+                'your', 'our', 'or', 'not', 'can', 'may', 'might', 'also', 'into', 'over', 'under', 'within'
+            ]);
+
+            const tokenCounts = [];
+            const docFreqs = {};
+
+            docs.forEach(doc => {
+                const sourceText = [
+                    doc.title || '',
+                    doc.abstract_snippet || '',
+                    doc.content || '',
+                    Array.isArray(doc.keywords) ? doc.keywords.join(' ') : ''
+                ].join(' ');
+                const tokens = (sourceText.toLowerCase().match(/[a-z0-9_]+/g) || [])
+                    .filter(token => token.length > 2 && !stopwords.has(token));
+                const counts = {};
+                tokens.forEach(token => {
+                    counts[token] = (counts[token] || 0) + 1;
+                });
+                tokenCounts.push({ counts, length: tokens.length });
+                const uniqueTokens = new Set(tokens);
+                uniqueTokens.forEach(token => {
+                    docFreqs[token] = (docFreqs[token] || 0) + 1;
+                });
+            });
+
+            const totalDocs = docs.length;
+            const idf = {};
+            Object.keys(docFreqs).forEach(token => {
+                idf[token] = Math.log((totalDocs + 1) / (docFreqs[token] + 1)) + 1;
+            });
+
+            searchIndex = { docs, tokenCounts, idf, totalDocs, stopwords };
+            return searchIndex;
+        }
+
+        function computeScores(query, index) {
+            const tokens = (query.toLowerCase().match(/[a-z0-9_]+/g) || [])
+                .filter(token => token.length > 2 && !index.stopwords.has(token));
+            if (tokens.length === 0) return [];
+            const queryCounts = {};
+            tokens.forEach(token => {
+                queryCounts[token] = (queryCounts[token] || 0) + 1;
+            });
+
+            const results = index.docs.map((doc, idx) => {
+                const { counts, length } = index.tokenCounts[idx];
+                if (length === 0) return null;
+                let score = 0;
+                Object.keys(queryCounts).forEach(token => {
+                    const tf = counts[token] || 0;
+                    if (!tf) return;
+                    const tfNorm = tf / length;
+                    const boost = 1 + Math.log(1 + queryCounts[token]);
+                    score += tfNorm * (index.idf[token] || 0) * boost;
+                });
+                if (score <= 0) return null;
+                return { doc, score };
+            }).filter(Boolean);
+
+            results.sort((a, b) => b.score - a.score);
+            return results;
+        }
+
+        function updateSearchSummary() {
+            const summary = document.getElementById('search-summary');
+            const totalPages = Math.max(1, Math.ceil(searchResults.length / searchPageSize));
+            if (searchResults.length === 0) {
+                summary.textContent = '結果がありません';
+                return;
+            }
+            summary.textContent = `${searchResults.length} 件中 ${searchPage} / ${totalPages} ページ`;
+        }
+
+        function updateSearchPagination() {
+            const totalPages = Math.max(1, Math.ceil(searchResults.length / searchPageSize));
+            const prevBtn = document.getElementById('search-prev');
+            const nextBtn = document.getElementById('search-next');
+            const info = document.getElementById('search-page-info');
+            info.textContent = `${searchPage} / ${totalPages}`;
+            prevBtn.disabled = searchPage <= 1;
+            nextBtn.disabled = searchPage >= totalPages;
+        }
+
+        function renderSearchResults() {
+            const container = document.getElementById('search-results');
+            container.innerHTML = '';
+            if (searchResults.length === 0) {
+                container.innerHTML = '<p style="color: var(--text-secondary);">結果がありません</p>';
+                updateSearchPagination();
+                return;
+            }
+
+            const start = (searchPage - 1) * searchPageSize;
+            const end = Math.min(searchResults.length, start + searchPageSize);
+            const slice = searchResults.slice(start, end);
+
+            let index = 0;
+            const chunkSize = 6;
+
+            const renderChunk = () => {
+                const chunk = slice.slice(index, index + chunkSize);
+                chunk.forEach(result => {
+                    const doc = result.doc;
+                    const snippet = doc.abstract_snippet || (doc.content || '').slice(0, 300);
+                    const keywords = Array.isArray(doc.keywords) ? doc.keywords.join(', ') : '-';
+                    const score = result.score.toFixed(3);
+                    const card = document.createElement('div');
+                    card.className = 'search-result';
+                    card.innerHTML = `
+                        <div class="search-result-title">${doc.title || 'Untitled'}</div>
+                        <div class="search-result-meta">Run: ${doc.run_id || '-'} | Score: ${score}</div>
+                        <div class="search-result-snippet">${highlightText(snippet, document.getElementById('search-input').value)}</div>
+                        <div class="search-result-meta">Keywords: ${keywords}</div>
+                    `;
+                    container.appendChild(card);
+                });
+                index += chunkSize;
+                if (index < slice.length) {
+                    requestAnimationFrame(renderChunk);
+                }
+            };
+
+            renderChunk();
+            updateSearchPagination();
+        }
+
         async function searchCorpus() {
-            const query = document.getElementById('search-input').value;
+            const query = document.getElementById('search-input').value.trim();
             if (!query) { showToast('検索キーワードを入力', 'warning'); return; }
 
             const container = document.getElementById('search-results');
             container.innerHTML = '<div class="spinner"></div>';
 
             try {
-                const res = await fetch(`${API_BASE}/api/search?q=${encodeURIComponent(query)}&top_k=20`);
-                const data = await res.json();
-
-                if (!data.results || data.results.length === 0) {
-                    container.innerHTML = '<p style="color: var(--text-secondary);">結果がありません</p>';
-                    return;
-                }
-
-                container.innerHTML = data.results.map(r => `
-                    <div class="search-result">
-                        <div class="search-result-title">${r.paper_title || 'Unknown Paper'}</div>
-                        <div class="search-result-meta">
-                            📍 ${r.locator?.section || 'Unknown'} | Score: ${r.score?.toFixed(2) || 0}
-                        </div>
-                        <div class="search-result-snippet">${highlightText(r.text?.substring(0, 300) || '', query)}...</div>
-                    </div>
-                `).join('');
+                const index = await loadSearchIndex();
+                searchPageSize = parseInt(document.getElementById('search-page-size').value, 10);
+                searchResults = computeScores(query, index);
+                searchPage = 1;
+                updateSearchSummary();
+                renderSearchResults();
             } catch (e) {
-                container.innerHTML = '<p style="color: var(--danger);">検索エラー</p>';
+                container.innerHTML = `<p style="color: var(--danger);">検索エラー: ${e.message}</p>`;
             }
+        }
+
+        function changeSearchPage(delta) {
+            const totalPages = Math.max(1, Math.ceil(searchResults.length / searchPageSize));
+            searchPage = Math.min(Math.max(1, searchPage + delta), totalPages);
+            updateSearchSummary();
+            renderSearchResults();
         }
 
         function highlightText(text, query) {
@@ -1146,9 +1330,30 @@
             showToast('更新しました');
         }
 
+        function initializeSearch() {
+            const input = document.getElementById('search-input');
+            const pageSizeSelect = document.getElementById('search-page-size');
+            if (input) {
+                input.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter') {
+                        searchCorpus();
+                    }
+                });
+            }
+            if (pageSizeSelect) {
+                pageSizeSelect.addEventListener('change', () => {
+                    searchPageSize = parseInt(pageSizeSelect.value, 10);
+                    searchPage = 1;
+                    updateSearchSummary();
+                    renderSearchResults();
+                });
+            }
+        }
+
         // === Initialize ===
         checkLocalServer(); // Check if local server is running
         loadRuns();
+        initializeSearch();
     </script>
 </body>
 

--- a/public/search/index.json
+++ b/public/search/index.json
@@ -1,0 +1,5 @@
+{
+  "generated_at": "1970-01-01T00:00:00Z",
+  "doc_count": 0,
+  "docs": []
+}

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+
+STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "he",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "will",
+    "with",
+    "this",
+    "these",
+    "those",
+    "we",
+    "you",
+    "your",
+    "our",
+    "or",
+    "not",
+    "can",
+    "may",
+    "might",
+    "also",
+    "into",
+    "over",
+    "under",
+    "within",
+}
+
+
+def read_text(path: pathlib.Path) -> str:
+    if path.suffix.lower() == ".json":
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return ""
+        parts = []
+        for key in ("text", "content", "abstract", "summary"):
+            value = data.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+        return "\n".join(parts)
+    return path.read_text(encoding="utf-8")
+
+
+def strip_markdown(text: str) -> str:
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"!\[[^\]]*\]\([^)]+\)", "", text)
+    text = re.sub(r"\[[^\]]+\]\([^)]+\)", "", text)
+    return text
+
+
+def extract_title(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = re.match(r"^#\s+(.*)", stripped)
+        if match:
+            return match.group(1).strip()
+        return stripped[:120]
+    return fallback
+
+
+def tokenize(text: str) -> List[str]:
+    tokens = re.findall(r"[A-Za-z0-9_]+", text.lower())
+    return [tok for tok in tokens if len(tok) > 2 and tok not in STOPWORDS]
+
+
+def extract_keywords(text: str, top_k: int = 8) -> List[str]:
+    counts: Dict[str, int] = {}
+    for token in tokenize(text):
+        counts[token] = counts.get(token, 0) + 1
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [token for token, _count in ranked[:top_k]]
+
+
+def find_candidate_files(run_dir: pathlib.Path) -> List[pathlib.Path]:
+    candidates = []
+    preferred_names = {
+        "report.md",
+        "report.txt",
+        "extracted_text.txt",
+        "extracted_text.md",
+        "abstract.txt",
+        "extracted_text.json",
+        "report.json",
+    }
+    for path in run_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.name in preferred_names:
+            candidates.append(path)
+            continue
+        if path.name.startswith("extracted_text") and path.suffix.lower() in {".txt", ".md", ".json"}:
+            candidates.append(path)
+    return candidates
+
+
+def load_summary(run_dir: pathlib.Path) -> Dict[str, Any]:
+    summary_path = run_dir / "summary.json"
+    if summary_path.exists():
+        try:
+            return json.loads(summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def build_docs(runs_dir: pathlib.Path) -> List[Dict[str, Any]]:
+    docs: List[Dict[str, Any]] = []
+    for run_dir in sorted(runs_dir.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        run_id = run_dir.name
+        summary = load_summary(run_dir)
+        run_id = summary.get("run_id") or run_id
+        candidates = find_candidate_files(run_dir)
+        if not candidates:
+            continue
+
+        combined_text_parts: List[str] = []
+        source_files = []
+        for path in candidates:
+            content = read_text(path).strip()
+            if not content:
+                continue
+            combined_text_parts.append(content)
+            source_files.append(str(path.relative_to(run_dir)))
+
+        if not combined_text_parts:
+            continue
+
+        combined_text = "\n\n".join(combined_text_parts)
+        clean_text = strip_markdown(combined_text)
+        title = extract_title(combined_text, fallback=f"Run {run_id}")
+        snippet = " ".join(clean_text.split())
+        abstract_snippet = snippet[:320] + ("..." if len(snippet) > 320 else "")
+        keywords = extract_keywords(clean_text)
+        tokens = tokenize(clean_text)
+        doc_id = f"{run_id}:{len(docs)}"
+        docs.append(
+            {
+                "doc_id": doc_id,
+                "run_id": run_id,
+                "title": title,
+                "abstract_snippet": abstract_snippet,
+                "keywords": keywords,
+                "content": clean_text,
+                "source_files": source_files,
+                "score_features": {
+                    "length_chars": len(clean_text),
+                    "length_tokens": len(tokens),
+                    "keyword_count": len(keywords),
+                    "status": summary.get("status"),
+                    "query": summary.get("query"),
+                },
+            }
+        )
+    return docs
+
+
+def write_index(output_path: pathlib.Path, docs: Iterable[Dict[str, Any]]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_list = list(docs)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "doc_count": len(doc_list),
+        "docs": doc_list,
+    }
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a lightweight search index for serverless search.")
+    parser.add_argument(
+        "--runs-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("public/runs"),
+        help="Path to the runs directory (default: public/runs)",
+    )
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("public/search/index.json"),
+        help="Output path for the index JSON (default: public/search/index.json)",
+    )
+    args = parser.parse_args()
+
+    docs = build_docs(args.runs_dir)
+    write_index(args.output, docs)
+    print(f"Wrote {len(docs)} docs to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Enable search in serverless deployments by removing reliance on a local API and generating a static search index from run artifacts. 
- Provide a lightweight, client-side ranking so the dashboard can perform searches purely in the browser for small corpora (approx. 50–200 runs). 
- Prevent UI slowdowns for larger result sets by adding pagination and lazy rendering. 
- Make the search experience available on GitHub Pages / static hosting without a Worker/API.

### Description
- Added `scripts/build_search_index.py` which scans `public/runs/*`, reads `summary.json` and common report/extracted text files, and emits a lightweight JSON index containing `doc_id`, `run_id`, `title`, `abstract_snippet`, `keywords`, `content`, `source_files`, and `score_features`.
- Added an initial empty index payload at `public/search/index.json` to ensure serverless deployments have a fallback index file.
- Updated `public/index.html` to show the Search tab in serverless mode and implemented a client-side TF‑IDF-like scorer (`loadSearchIndex`, `computeScores`) that loads `public/search/index.json`, ranks documents in the browser, and returns results.
- Implemented pagination controls, page-size selection, and lazy rendering (chunked render via `requestAnimationFrame`) to mitigate UI stalls when many results are present.

### Testing
- Started a static server with `python -m http.server` serving the `public` directory and confirmed `index.html` is served (HTTP 200).
- Attempted automated UI checks with Playwright to open the dashboard search tab and interact with the search input, but the Playwright runs timed out / failed to interact reliably, so UI validation is incomplete.
- Verified the new files (`scripts/build_search_index.py` and `public/search/index.json`) are present and the index writer prints a summary when run (manual invocation supported). 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695367f0b4c08330a65adfa55e71a388)