### PR TITLE
Secure worker write endpoints and tighten CORS

### DIFF
--- a/docs/ops/security_model.md
+++ b/docs/ops/security_model.md
@@ -1,0 +1,57 @@
+# Security Model
+
+## Goals
+
+- Prevent powerful tokens from being exposed to browsers.
+- Ensure write endpoints require explicit authorization.
+- Restrict CORS so read-only APIs are accessible only from approved origins.
+
+## Trust Boundary
+
+- **Browser**: Untrusted. Only read-only endpoints are accessible via CORS.
+- **Worker**: Enforces authentication for write operations.
+- **GitHub Actions**: Uses a dedicated token for status updates and workflow dispatch.
+
+## Authentication
+
+All write endpoints **must** include `Authorization: Bearer <token>`.
+
+| Endpoint | Method | Required Token | Purpose |
+| --- | --- | --- | --- |
+| `/dispatch` or `/` | POST | `DISPATCH_TOKEN` | Trigger GitHub Actions workflow dispatch. |
+| `/schedule/create` | POST | `SCHEDULE_TOKEN` | Create scheduled runs. |
+| `/schedule/toggle` | POST | `SCHEDULE_TOKEN` | Enable/disable schedules. |
+| `/status/update` | POST | `STATUS_TOKEN` | Update run status from GitHub Actions. |
+
+Tokens are stored as Worker secrets and must never be embedded in browser code.
+
+## CORS Policy
+
+Read-only endpoints are public **but** CORS is restricted:
+
+- **Allowed methods**: `GET` only.
+- **Allowed origins**: GitHub Pages origin only by default (e.g. `https://kaneko-ai.github.io`).
+- **Local development**: Add local origins via `ALLOWED_ORIGINS` (comma-separated) if needed.
+
+Endpoints with CORS enabled:
+
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/status` | GET | Polling run status. |
+| `/schedule/list` | GET | List schedules for UI. |
+
+Write endpoints do not send CORS headers, so browsers cannot call them directly.
+
+## Configuration
+
+Worker environment variables:
+
+- `ALLOWED_ORIGINS`: Comma-separated list of approved origins.
+- `DISPATCH_TOKEN`: Bearer token for dispatch.
+- `SCHEDULE_TOKEN`: Bearer token for schedule writes.
+- `STATUS_TOKEN`: Bearer token for status updates.
+
+## Validation Checklist
+
+- Anonymous POST requests are rejected.
+- CORS is not `*` and only allows `GET` from approved origins.


### PR DESCRIPTION
### Motivation

- Prevent powerful tokens from being exposed to browsers by enforcing a strict trust boundary between UI and worker.
- Ensure write operations (dispatch, schedule create/toggle, status update) cannot be invoked anonymously from client-side code.
- Restrict read-only browser access to a limited set of safe GET endpoints with explicit origin checks.

### Description

- Updated `cloudflare-worker.js` to require `Authorization: Bearer <token>` for dispatch (`/` or `/dispatch`), schedule writes (`/schedule/create`, `/schedule/toggle`), and status updates (`/status/update`) via a new `requireBearerToken` helper and added `DISPATCH_TOKEN` to required secrets.
- Replaced permissive CORS with `parseAllowedOrigins` and `corsHeadersForRequest` so only `GET` requests from origins in `ALLOWED_ORIGINS` (default `https://kaneko-ai.github.io`) receive CORS headers, and write endpoints no longer expose CORS headers.
- Removed legacy `X-STATUS-TOKEN`/`X-SCHEDULE-TOKEN` header usage in favor of standard `Authorization` bearer tokens and centralized authentication checks.
- Added `docs/ops/security_model.md` documenting the security model, required Worker env vars, token mapping, and CORS policy.

### Testing

- No automated tests were run as part of this change.
- The change is limited to request handling and documentation and should be verified in a staging Worker with appropriate secrets set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536ac8e1ec8330a23ea079d336e919)