### PR TITLE
Fix schedule navigation and improve API error reporting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -657,7 +657,7 @@
             <div class="section">
                 <h2>🗓️ スケジューラ</h2>
                 <p style="color: var(--warning); margin-bottom: 12px;">⚠️ Local APIが必要です（Serverlessでは利用不可）</p>
-                <button class="btn btn-secondary" onclick="window.location.href='dashboard/schedule.html'">スケジューラを開く</button>
+                <button class="btn btn-secondary" onclick="window.location.href='schedule.html'">スケジューラを開く</button>
             </div>
         </div>
 

--- a/public/schedule.html
+++ b/public/schedule.html
@@ -240,11 +240,20 @@
 
     async function apiFetch(path, options = {}) {
       const res = await fetch(`${apiBase}${path}`, options);
-      const data = await res.json();
-      if (!res.ok || data.ok === false) {
-        throw new Error(data.error || 'request failed');
+      const text = await res.text();
+      let data = null;
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch (err) {
+          data = null;
+        }
       }
-      return data;
+      if (!res.ok || (data && data.ok === false)) {
+        const body = text || '(empty body)';
+        throw new Error(`HTTP ${res.status}: ${body}`);
+      }
+      return data ?? { ok: true };
     }
 
     async function loadSchedules() {


### PR DESCRIPTION
### Motivation
- Ensure the Schedule UI is reachable from the Pages root to eliminate 404s caused by references to `dashboard/schedule.html`.
- Surface meaningful API errors (HTTP status and response body) in the Schedule UI so failures are visible to the user.
- Avoid relying on JSON-only responses from the schedule API to prevent unhandled parse errors.

### Description
- Updated the Schedule button in `public/index.html` to point to `schedule.html` instead of `dashboard/schedule.html`.
- Reworked the `apiFetch` helper in `public/schedule.html` to read raw response text, safely attempt JSON parsing, and include `HTTP <status>: <body>` in thrown errors when requests fail.
- Added a fallback return of `{ ok: true }` when responses have no JSON body to keep the UI operational.

### Testing
- No automated tests were run for these static HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a2e8567c8330bd52b4da3f51538e)