### PR TITLE
Fix jarvis_web import side effects and standardize uvicorn factory startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
 # Run
-CMD ["~/.local/bin/uv", "run", "uvicorn", "jarvis_web.app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["~/.local/bin/uv", "run", "uvicorn", "jarvis_web.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -56,6 +56,9 @@ pip install google-generativeai
 ### Web API
 ```bash
 pip install fastapi uvicorn
+
+# Run the API locally
+uvicorn jarvis_web.app:create_app --factory --host 0.0.0.0 --port 8000
 ```
 
 ### Embeddings

--- a/jarvis_web/__init__.py
+++ b/jarvis_web/__init__.py
@@ -1,12 +1,11 @@
 """Web package."""
 try:
-    from .app import app, create_app, run_server
+    from .app import create_app, run_server
     from .dashboard import DashboardAPI
-    __all__ = ["app", "create_app", "run_server", "DashboardAPI"]
+    __all__ = ["create_app", "run_server", "DashboardAPI"]
 except ImportError:
     try:
         from .dashboard import DashboardAPI
         __all__ = ["DashboardAPI"]
     except ImportError:
         __all__ = []
-


### PR DESCRIPTION
### Motivation
- Prevent importing `jarvis_web` from performing side-effect app initialization so imports used by contract tests do not fail.
- Expose only safe creation helpers (e.g. `create_app`) from the package to avoid accidental runtime initialization.
- Standardize how the server is started so deployed containers call the factory rather than relying on a pre-instantiated `app`.
- Update documentation to reflect the recommended factory-based `uvicorn` startup command.

### Description
- Removed direct `app` import from `jarvis_web.__init__` so importing the package no longer creates a running FastAPI app and updated `__all__` to expose `create_app` and `run_server` only.
- Changed the Dockerfile command to start uvicorn with the application factory: `jarvis_web.app:create_app` plus `--factory`.
- Documented the factory-based local startup in `docs/INSTALL.md` with the `uvicorn jarvis_web.app:create_app --factory ...` command.
- Kept `run_server` and `create_app` API intact in `jarvis_web.app` so runtime behavior is unchanged when explicitly invoked.

### Testing
- No automated tests were executed as part of this change.
- Manual inspection verified the import change removes `app` from `jarvis_web.__init__` and updates `__all__` to only export `create_app` and `run_server`.
- Dockerfile change was applied to use the uvicorn factory entrypoint instead of referencing `jarvis_web.app:app`.
- Documentation updated to instruct users to run the server via the factory-based `uvicorn` command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a6f87cc08330bd6ebd21c9b9728a)