### PR TITLE
Unify /health handlers and point API map generator at contracts

### DIFF
--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -349,6 +349,7 @@ def load_qa_summary(run_id: str) -> Optional[dict]:
 if FASTAPI_AVAILABLE:
 
     @app.get("/api/health")
+    @app.get("/health")
     async def health():
         """Health check endpoint."""
         return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
@@ -901,11 +902,6 @@ if FASTAPI_AVAILABLE:
 
 # Legacy compatibility endpoints
 if FASTAPI_AVAILABLE:
-
-    @app.get("/health")
-    async def health_legacy():
-        """Legacy health check."""
-        return await health()
 
     @app.get("/runs")
     async def list_runs_legacy(limit: int = 10, _: bool = Depends(verify_token)):

--- a/scripts/generate_api_map.py
+++ b/scripts/generate_api_map.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-API_MAP_PATH = ROOT / "schemas" / "api_map_v1.json"
+API_MAP_PATH = ROOT / "jarvis_web" / "contracts" / "api_map_v1.json"
 
 API_MAP = {
     "version": "v1",


### PR DESCRIPTION
### Motivation

- Avoid route collisions and make health checks robust to UI path variations by serving the same response for both `/api/health` and `/health`.
- Ensure the API map generator writes to the actual contract location used by the app at `jarvis_web/contracts/api_map_v1.json`.
- Align runtime routes and generated contract artefacts so front adapters and middleware see a consistent `api_map`.
- Reduce legacy duplicate handlers and simplify route surface to prevent accidental double-definition.

### Description

- Added `@app.get("/health")` to the existing `health` handler so `GET /health` and `GET /api/health` share one implementation and removed the old `health_legacy` wrapper in `jarvis_web/app.py`.
- Updated `API_MAP_PATH` in `scripts/generate_api_map.py` to write the output to `jarvis_web/contracts/api_map_v1.json` instead of `schemas/api_map_v1.json`.
- Modified files: `jarvis_web/app.py` and `scripts/generate_api_map.py` to reflect these changes.
- No changes to capability enumeration logic were made beyond removing the legacy health wrapper to prevent route duplication.

### Testing

- No automated tests were executed as part of this change.
- The change is limited to route decorators and a script constant, and should be safe to validate via the existing test suite that exercises `/api/health`, `/health`, and the API map generation.
- Recommend running `pytest tests/test_api_map_vs_capabilities.py` and `pytest tests/smoke_api_v1.py` in CI to verify contract consistency and endpoint availability.
- Manual verification: starting the FastAPI app should not report route collisions and both health endpoints should return HTTP 200 and the same payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a7b18e548330bae41df17e1fe804)