### PR TITLE
Regenerate sample PDF fixture and add generator script

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -17,6 +17,7 @@ scikit-learn>=1.3.0
 PyMuPDF>=1.22.0,<2.0
 PyPDF2>=3.0.0,<4.0
 pdfminer.six>=20221105
+reportlab>=4.0.0,<5.0
 
 # Testing
 pytest>=7.0.0,<8.0
@@ -31,4 +32,3 @@ pytest-cov>=4.0.0
 
 # Optional: Embeddings
 # sentence-transformers>=2.2.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ joblib
 pymupdf
 python-docx
 python-pptx
+reportlab

--- a/scripts/generate_test_pdf.py
+++ b/scripts/generate_test_pdf.py
@@ -1,0 +1,26 @@
+"""Generate a sample PDF fixture for tests."""
+from pathlib import Path
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "tests" / "fixtures" / "sample.pdf"
+
+
+def generate_pdf(output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf = canvas.Canvas(str(output_path), pagesize=letter)
+    width, height = letter
+
+    for page_number in range(1, 4):
+        pdf.setFont("Helvetica", 16)
+        pdf.drawString(72, height - 72, f"Page {page_number}")
+        pdf.showPage()
+
+    pdf.save()
+
+
+if __name__ == "__main__":
+    generate_pdf(OUTPUT_PATH)

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f760207f0db85c2cd4559590892fc70ee8049041659ce768b134d5e3e4aa5ed9
-size 1400
+oid sha256:9af149c26e4b8f87a6819afc3f778a6570a372cf2453d6e4bb3981fdb37eb8a1
+size 1388


### PR DESCRIPTION
### Motivation
- Prevent PDF extraction tests from failing due to a malformed or incomplete `tests/fixtures/sample.pdf` test asset.
- Provide a reproducible script to regenerate the sample PDF fixture used by PDF pipeline tests.

### Description
- Add `scripts/generate_test_pdf.py`, a ReportLab-based script that generates a 3-page PDF with `Page 1`, `Page 2`, and `Page 3` on each page.
- Replace the binary `tests/fixtures/sample.pdf` with a refreshed 3-page PDF containing the expected page text.
- Add `reportlab` to `requirements.txt` and `requirements.lock` so the generator script can be installed and used.

### Testing
- Running `python scripts/generate_test_pdf.py` failed with `ModuleNotFoundError` because `reportlab` was not installed, which prompted adding it to requirements (failure observed).
- As a verification step, a small automated script using `PyMuPDF` (`fitz`) opened `tests/fixtures/sample.pdf` and confirmed `page_count == 3` and that each page contains the expected `Page 1`/`Page 2`/`Page 3` text (success).
- No test suite (`pytest`) was run in this rollout, so `tests/test_pdf_extractor.py` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a957eb588330bde6ebf2efd0e0ea)