### PR TITLE
Add optional `message` field to TelemetryEvent (Telemetry v2)

### DIFF
--- a/jarvis_core/telemetry/schema.py
+++ b/jarvis_core/telemetry/schema.py
@@ -63,6 +63,7 @@ class TelemetryEvent:
     subtask_id: Optional[str] = None
     agent: Optional[str] = None
     tool: Optional[str] = None
+    message: Optional[str] = None
 
     # Payload (no chain-of-thought!)
     payload: Dict[str, Any] = field(default_factory=dict)
@@ -93,6 +94,7 @@ class TelemetryEvent:
         event: str,
         event_type: str,
         level: str = "INFO",
+        message: Optional[str] = None,
         **kwargs,
     ) -> "TelemetryEvent":
         """Factory method for creating events."""
@@ -104,5 +106,6 @@ class TelemetryEvent:
             step_id=step_id,
             event=event,
             event_type=event_type,
+            message=message,
             **kwargs,
         )


### PR DESCRIPTION
### Motivation
- Ensure telemetry events conform to the Telemetry v2 contract by including an optional `message` field. 
- Provide a short, human-readable message field for error/run events without changing existing payload semantics. 
- Preserve downstream observability and backward compatibility with existing event fields and `to_dict` behavior.

### Description
- Add `message: Optional[str] = None` to the `TelemetryEvent` dataclass in `jarvis_core/telemetry/schema.py`.
- Extend the `TelemetryEvent.create` factory to accept a `message` parameter and pass it through to the constructor via `message=message`.
- Keep existing `to_dict` behavior and timestamp aliasing (`timestamp`) intact by leaving serialization logic unchanged.

### Testing
- Ran `pytest -q tests/test_telemetry_contract_v2.py` to validate the telemetry contract tests. 
- All tests in that file passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b1392b3c833081194db58aee8cba)