### PR TITLE
Make KeywordExtractor ordering deterministic

### DIFF
--- a/docs/contracts/keyword_extractor.md
+++ b/docs/contracts/keyword_extractor.md
@@ -1,0 +1,25 @@
+# KeywordExtractor Contract
+
+## Purpose
+Define the deterministic behavior of `KeywordExtractor.extract` so keyword ordering is stable across runs.
+
+## Inputs
+- **text**: Source text to analyze.
+- **top_n**: Maximum number of keywords to return.
+
+## Tokenization & Filtering
+- Tokens are extracted using the regex `\b[a-zA-Z]{3,}\b` and lowercased.
+- Stopwords are removed using `KeywordExtractor.STOPWORDS`.
+
+## Scoring
+- Each keyword receives a score equal to its frequency count in the filtered token list.
+
+## Sorting (Deterministic Tie-Break)
+Keywords are sorted using the following keys in order:
+1. **Primary**: score descending (higher frequency first)
+2. **Secondary**: first occurrence position ascending (earlier in the filtered token list first)
+3. **Tertiary**: keyword lexicographic order ascending (dictionary order)
+
+## Output
+- Returns a list of `(keyword, count)` tuples ordered by the deterministic sort described above.
+- The list is truncated to `top_n` entries.

--- a/jarvis_core/ai/features.py
+++ b/jarvis_core/ai/features.py
@@ -300,7 +300,16 @@ class KeywordExtractor:
         filtered = [w for w in words if w not in self.STOPWORDS]
         
         counter = Counter(filtered)
-        return counter.most_common(top_n)
+        first_positions = {}
+        for index, word in enumerate(filtered):
+            if word not in first_positions:
+                first_positions[word] = index
+
+        sorted_keywords = sorted(
+            counter.items(),
+            key=lambda item: (-item[1], first_positions[item[0]], item[0])
+        )
+        return sorted_keywords[:top_n]
     
     def extract_phrases(self, text: str, top_n: int = 5) -> List[str]:
         """Extract key phrases (bigrams).


### PR DESCRIPTION
### Motivation
- Tests were flaky because keyword ordering could vary when multiple tokens had equal scores, causing nondeterministic failures.
- Ensure stable, repeatable ordering for extracted keywords by defining explicit tie-break rules.
- Make the behavior explicit in project documentation so callers can rely on deterministic output.

### Description
- Update `KeywordExtractor.extract` to compute `first_positions` and sort `counter.items()` with keys `(-count, first_positions[word], word)` to enforce deterministic ordering.
- Replace the previous `counter.most_common(top_n)` with the deterministic `sorted(... )[:top_n]` result in `jarvis_core/ai/features.py`.
- Add `docs/contracts/keyword_extractor.md` that documents tokenization, scoring, and the three-level tie-break (score desc, first-occurrence asc, lexicographic asc).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b1c944c08330a587effbed4204b2)