### PR TITLE
Make adapter manifest JSON compatible

### DIFF
--- a/dashboard/assets/adapter_manifest.js
+++ b/dashboard/assets/adapter_manifest.js
@@ -1,5 +1,5 @@
 export const ADAPTER_REQUIREMENTS = {
-    core: [
+    "core": [
         "capabilities",
         "health",
         "runs_list",
@@ -7,12 +7,12 @@ export const ADAPTER_REQUIREMENTS = {
         "run_files",
         "run_file_get"
     ],
-    research: ["research_rank", "research_paper"],
-    qa: ["qa_report"],
-    submission: ["submission_build", "submission_latest"],
-    decision: ["decision_simulate"],
-    finance: ["finance_optimize", "finance_simulate", "finance_download"],
-    dashboard: [
+    "research": ["research_rank", "research_paper"],
+    "qa": ["qa_report"],
+    "submission": ["submission_build", "submission_latest"],
+    "decision": ["decision_simulate"],
+    "finance": ["finance_optimize", "finance_simulate", "finance_download"],
+    "dashboard": [
         "run_manifest",
         "jobs",
         "job_detail",


### PR DESCRIPTION
### Motivation
- The front-end adapter manifest is consumed by a Python test that uses `json.loads()`, so the manifest body must be strict JSON-compatible value syntax.
- Currently some object keys in `dashboard/assets/adapter_manifest.js` were unquoted, causing `json.loads()` to fail when extracting `ADAPTER_REQUIREMENTS`.

### Description
- Updated `dashboard/assets/adapter_manifest.js` to quote all top-level keys in the `ADAPTER_REQUIREMENTS` object so the captured object is valid JSON. 
- Kept the file as a JS module export (`export const ADAPTER_REQUIREMENTS = ...;`) while ensuring the object literal is strict JSON-compatible.

### Testing
- No automated tests were executed as part of this rollout.
- The change was made to satisfy `tests/test_front_adapter_contract.py` which extracts `ADAPTER_REQUIREMENTS` and parses it with `json.loads()` so it should now be able to parse the manifest successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b37b60248330a3e03f368ea7eca4)