### PR TITLE
Add CI sweep gate before deploy

### DIFF
--- a/.github/workflows/jarvis_dispatch.yml
+++ b/.github/workflows/jarvis_dispatch.yml
@@ -123,6 +123,9 @@ jobs:
 
       - name: Run tests
         run: pytest -q
+      
+      - name: Run CI sweep
+        run: python scripts/ci_sweep.py --fail-if-any
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
### Motivation

- Prevent a broken or red CI state from being published by blocking deploys until critical checks pass.
- Make the dispatch workflow enforce a final sweep that fails the job on any detected issues.

### Description

- Added a `Run CI sweep` workflow step that runs `python scripts/ci_sweep.py --fail-if-any` in `.github/workflows/jarvis_dispatch.yml`.
- The new step is inserted after the `pytest -q` step and before Node setup and deploy steps to act as a gating check.
- The `--fail-if-any` flag ensures the workflow exits non-zero if any sweep failures are found, preventing subsequent deploy steps.

### Testing

- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b89908588330a1308dc33cff1f46)