### PR TITLE
Add static-site Playwright E2E for public dashboard

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
-const baseURL = process.env.DASHBOARD_BASE_URL || 'http://localhost:4173';
+const serverPort = process.env.DASHBOARD_PORT || '8000';
+const baseURL = process.env.DASHBOARD_BASE_URL || `http://localhost:${serverPort}`;
 
 export default defineConfig({
   testDir: __dirname,
@@ -16,5 +17,10 @@ export default defineConfig({
     video: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },
-  reporter: [['list']]
+  reporter: [['list']],
+  webServer: {
+    command: `python -m http.server ${serverPort} --directory public`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/e2e/public-dashboard.spec.ts
+++ b/tests/e2e/public-dashboard.spec.ts
@@ -28,4 +28,11 @@ test.describe('public dashboard e2e', () => {
     await page.getByRole('button', { name: '検索' }).click();
     await expect(page.locator('.search-result-title')).toContainText('Fixture Paper on Biology');
   });
+
+  test('search index is readable', async ({ request }) => {
+    const response = await request.get('/search/index.json');
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+    expect(Array.isArray(data)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
### Motivation
- Add a minimal E2E smoke test for the static `public/` site to catch breakage in the "list → detail → report" flow early.
- Ensure the `search/index.json` used by the UI remains readable as part of the E2E checks.
- Run Playwright against a locally served static site so tests exercise the actual artifacts shipped in `public/`.
- Make the check suitable for CI gating so broken front-end artifacts stop deploys.

### Description
- Configure Playwright in `tests/e2e/playwright.config.ts` to serve `public/` using `python -m http.server` via the `webServer` option and expose a configurable `DASHBOARD_PORT` (default `8000`).
- Set the Playwright `baseURL` to `http://localhost:${serverPort}` and enable `reuseExistingServer` when not running in CI.
- Extend `tests/e2e/public-dashboard.spec.ts` with a new test that requests `/search/index.json` via Playwright `request` and asserts the response is OK and JSON is an array.
- Keep existing UI checks for index rendering, runs list, and run detail manifest/report in the same spec to cover the full minimal path.

### Testing
- No automated test suite was executed as part of this change (Playwright is configured but not run in this patch).
- Local repository inspection confirms fixture run data exists under `public/runs/fixture_run` and `public/search/index.json` is present for the new spec to exercise.
- The Playwright config uses `reuseExistingServer: !process.env.CI` so local iterative runs will reuse an existing server when present.
- Manual commit and file updates were made and saved; running `npm run test:e2e` will execute the Playwright tests against the served `public/` site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953bad810ec833090e5ded6712b5e20)