### PR TITLE
Add Definition of Done and Architecture Decisions docs

### DIFF
--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -1,0 +1,10 @@
+# Architecture Decisions
+
+## Runtime and deployment boundaries
+
+- Serverless (Pages) must only reference the manifest and static artifacts.
+- The local API is a supporting tool and must not be a required dependency for Pages.
+
+## Bundle assembly
+
+- The canonical bundle implementation is consolidated in `jarvis_core/bundle/assembler.py`.

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -1,0 +1,9 @@
+# Definition of Done
+
+All of the following conditions must be satisfied for work to be considered complete:
+
+- `make ci-sweep` failures are `0`.
+- `audit_ui_contract` is `0`.
+- `pytest -q` failures are `0`.
+- E2E tests succeed.
+- Deploy gate is enabled.


### PR DESCRIPTION
### Motivation

- Prevent operational confusion by fixing and publicizing the team’s completion rules in one place.
- Ensure work is only marked complete when CI and quality gates like `make ci-sweep`, `audit_ui_contract`, `pytest -q`, E2E, and deploy gate requirements are satisfied.
- Clarify runtime and deployment boundaries so Serverless (Pages) only references manifests and static artifacts.
- Consolidate the canonical bundle implementation location to `jarvis_core/bundle/assembler.py` to avoid divergent implementations.

### Description

- Add `docs/DEFINITION_OF_DONE.md` containing the checklist of completion conditions including `make ci-sweep`, `audit_ui_contract`, `pytest -q`, E2E, and deploy gate.
- Add `docs/ARCHITECTURE_DECISIONS.md` documenting that Pages should reference only manifest/static artifacts, the local API is optional, and the canonical bundle assembler location is `jarvis_core/bundle/assembler.py`.
- Both files are added under `docs/` as documentation-only changes to lock down process and architecture expectations.
- No application code changes were made in this PR.

### Testing

- No automated tests were run because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953be6de8988330bd731db63bb8a625)