### PR TITLE
Add browser subagent scaffolding, Playwright core, security, recording and site-specific agents

### DIFF
--- a/configs/browser_security.yaml
+++ b/configs/browser_security.yaml
@@ -1,0 +1,12 @@
+js_execution: false
+url_allow_list:
+  - "pubmed.ncbi.nlm.nih.gov"
+  - "ncbi.nlm.nih.gov"
+  - "arxiv.org"
+  - "doi.org"
+  - "europepmc.org"
+  - "semanticscholar.org"
+url_deny_list:
+  - "facebook.com"
+  - "twitter.com"
+  - "instagram.com"

--- a/jarvis_core/browser/__init__.py
+++ b/jarvis_core/browser/__init__.py
@@ -1,0 +1,19 @@
+"""Browser subagent package."""
+
+from jarvis_core.browser.schema import (
+    BrowserAction,
+    BrowserActionResult,
+    BrowserState,
+    SecurityPolicy,
+)
+from jarvis_core.browser.security import BrowserSecurityManager
+from jarvis_core.browser.subagent import BrowserSubagent
+
+__all__ = [
+    "BrowserAction",
+    "BrowserActionResult",
+    "BrowserState",
+    "SecurityPolicy",
+    "BrowserSecurityManager",
+    "BrowserSubagent",
+]

--- a/jarvis_core/browser/agents/__init__.py
+++ b/jarvis_core/browser/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Browser agents package."""
+
+from jarvis_core.browser.agents.arxiv import ArxivBrowserAgent
+from jarvis_core.browser.agents.pdf_download import PDFDownloadAgent
+from jarvis_core.browser.agents.pubmed import PubMedBrowserAgent
+
+__all__ = ["ArxivBrowserAgent", "PDFDownloadAgent", "PubMedBrowserAgent"]

--- a/jarvis_core/browser/agents/arxiv.py
+++ b/jarvis_core/browser/agents/arxiv.py
@@ -1,0 +1,46 @@
+"""arXiv specific browser agent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jarvis_core.browser.subagent import BrowserSubagent
+
+
+class ArxivBrowserAgent(BrowserSubagent):
+    """Browser automation tailored to arXiv."""
+
+    BASE_URL = "https://arxiv.org/"
+    SEARCH_URL = "https://arxiv.org/search/"
+    SEARCH_INPUT = "input#query"
+    RESULT_ITEM = "li.arxiv-result"
+    RESULT_TITLE = "p.title"
+    RESULT_ID = "p.list-title"
+    ABSTRACT_SECTION = "blockquote.abstract"
+
+    async def search(self, query: str, max_results: int = 10) -> list[dict[str, Any]]:
+        await self.navigate(f"{self.SEARCH_URL}?query={query}&searchtype=all")
+        await self._ensure_initialized()
+        results = []
+        items = await self.session.page.query_selector_all(self.RESULT_ITEM)
+        for item in items[:max_results]:
+            title_el = await item.query_selector(self.RESULT_TITLE)
+            id_el = await item.query_selector(self.RESULT_ID)
+            title = await title_el.inner_text() if title_el else None
+            raw_id = await id_el.inner_text() if id_el else ""
+            arxiv_id = raw_id.replace("arXiv:", "").strip()
+            link_el = await item.query_selector("p.list-title a")
+            link = await link_el.get_attribute("href") if link_el else None
+            results.append({"title": title, "arxiv_id": arxiv_id, "link": link})
+        return results
+
+    async def get_abstract(self, arxiv_id: str) -> str:
+        await self.navigate(f"{self.BASE_URL}abs/{arxiv_id}")
+        await self._ensure_initialized()
+        abstract_el = await self.session.page.query_selector(self.ABSTRACT_SECTION)
+        if abstract_el is None:
+            return ""
+        return await abstract_el.inner_text()
+
+    async def get_pdf_url(self, arxiv_id: str) -> str:
+        return f"{self.BASE_URL}pdf/{arxiv_id}.pdf"

--- a/jarvis_core/browser/agents/pdf_download.py
+++ b/jarvis_core/browser/agents/pdf_download.py
@@ -1,0 +1,64 @@
+"""PDF download agent."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+
+@dataclass
+class PDFDownloadAgent:
+    """Agent that locates and downloads PDFs."""
+
+    unpaywall_email: str = "jarvis@kaneko-ai.dev"
+
+    async def download(self, url: str, output_path: Path) -> bool:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        response = await asyncio.to_thread(requests.get, url, timeout=30)
+        if response.status_code != 200:
+            return False
+        output_path.write_bytes(response.content)
+        return True
+
+    async def find_pdf_link(self, page_url: str) -> str | None:
+        if self._looks_like_doi(page_url):
+            oa_link = await self._fetch_unpaywall_link(page_url)
+            if oa_link:
+                return oa_link
+        response = await asyncio.to_thread(requests.get, page_url, timeout=30)
+        if response.status_code != 200:
+            return None
+        return self._extract_pdf_link(page_url, response.text)
+
+    async def _fetch_unpaywall_link(self, doi: str) -> str | None:
+        api_url = f"https://api.unpaywall.org/v2/{doi}?email={self.unpaywall_email}"
+        response = await asyncio.to_thread(requests.get, api_url, timeout=30)
+        if response.status_code != 200:
+            return None
+        payload: dict[str, Any] = response.json()
+        location = payload.get("best_oa_location") or {}
+        return location.get("url_for_pdf")
+
+    @staticmethod
+    def default_output_path(filename: str) -> Path:
+        return Path("downloads") / filename
+
+    @staticmethod
+    def _extract_pdf_link(base_url: str, html: str) -> str | None:
+        for match in re.findall(r'href=["\'](.*?)["\']', html, flags=re.IGNORECASE):
+            if match.lower().endswith(".pdf"):
+                return urljoin(base_url, match)
+        return None
+
+    @staticmethod
+    def _looks_like_doi(text: str) -> bool:
+        parsed = urlparse(text)
+        if parsed.scheme in {"http", "https"}:
+            return False
+        return text.startswith("10.")

--- a/jarvis_core/browser/agents/pubmed.py
+++ b/jarvis_core/browser/agents/pubmed.py
@@ -1,0 +1,57 @@
+"""PubMed specific browser agent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jarvis_core.browser.schema import BrowserActionResult
+from jarvis_core.browser.subagent import BrowserSubagent
+
+
+class PubMedBrowserAgent(BrowserSubagent):
+    """Browser automation tailored to PubMed."""
+
+    BASE_URL = "https://pubmed.ncbi.nlm.nih.gov/"
+    SEARCH_INPUT = "input#id_term"
+    SEARCH_FORM = "form#search-form"
+    RESULT_ITEMS = "article.full-docsum"
+    RESULT_TITLE = "a.docsum-title"
+    RESULT_PMID = "span.docsum-pmid"
+    ABSTRACT_SECTION = "div.abstract-content"
+    PDF_LINK = "a.link-item"  # often includes PDF or publisher link
+
+    async def search(self, query: str, max_results: int = 10) -> list[dict[str, Any]]:
+        await self.navigate(f"{self.BASE_URL}?term={query}")
+        await self._ensure_initialized()
+        results = []
+        items = await self.session.page.query_selector_all(self.RESULT_ITEMS)
+        for item in items[:max_results]:
+            title_el = await item.query_selector(self.RESULT_TITLE)
+            pmid_el = await item.query_selector(self.RESULT_PMID)
+            title = await title_el.inner_text() if title_el else None
+            pmid = await pmid_el.inner_text() if pmid_el else None
+            link = await title_el.get_attribute("href") if title_el else None
+            results.append({"title": title, "pmid": pmid, "link": link})
+        return results
+
+    async def get_abstract(self, pmid: str) -> str:
+        await self.navigate(f"{self.BASE_URL}{pmid}/")
+        await self._ensure_initialized()
+        abstract_el = await self.session.page.query_selector(self.ABSTRACT_SECTION)
+        if abstract_el is None:
+            return ""
+        return await abstract_el.inner_text()
+
+    async def download_pdf_link(self, pmid: str) -> str | None:
+        await self.navigate(f"{self.BASE_URL}{pmid}/")
+        await self._ensure_initialized()
+        links = await self.session.page.query_selector_all(self.PDF_LINK)
+        for link in links:
+            href = await link.get_attribute("href")
+            text = (await link.inner_text()).lower() if link else ""
+            if href and "pdf" in text:
+                return href
+        return None
+
+    async def navigate(self, url: str) -> BrowserActionResult:
+        return await super().navigate(url)

--- a/jarvis_core/browser/recording.py
+++ b/jarvis_core/browser/recording.py
@@ -1,0 +1,55 @@
+"""Recording utilities for browser actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class BrowserRecorder:
+    """Capture browser screenshots as a recording."""
+
+    session_id: str
+    base_dir: Path = Path("logs/browser_recordings")
+    frame_paths: list[Path] = field(default_factory=list)
+    active: bool = False
+
+    def start_recording(self) -> None:
+        self.active = True
+        self.frame_paths.clear()
+        self._ensure_dir()
+
+    def capture_frame(self, image_bytes: bytes | None = None) -> Path:
+        if not self.active:
+            raise RuntimeError("Recording is not active.")
+        if image_bytes is None:
+            raise ValueError("image_bytes is required to capture a frame.")
+        frame_index = len(self.frame_paths) + 1
+        frame_path = self._session_dir() / f"frame_{frame_index:04d}.png"
+        frame_path.write_bytes(image_bytes)
+        self.frame_paths.append(frame_path)
+        return frame_path
+
+    def stop_recording(self) -> Path:
+        if not self.active:
+            self._ensure_dir()
+            return self._session_dir()
+        self.active = False
+        return self._session_dir()
+
+    def list_frames(self) -> Iterable[Path]:
+        return list(self.frame_paths)
+
+    def _ensure_dir(self) -> None:
+        self._session_dir().mkdir(parents=True, exist_ok=True)
+
+    def _session_dir(self) -> Path:
+        return self.base_dir / self.session_id
+
+
+def generate_session_id(prefix: str = "browser") -> str:
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    return f"{prefix}_{timestamp}"

--- a/jarvis_core/browser/schema.py
+++ b/jarvis_core/browser/schema.py
@@ -1,0 +1,53 @@
+"""Schemas for browser subagent operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class BrowserAction(Enum):
+    """Supported browser actions."""
+
+    NAVIGATE = "navigate"
+    CLICK = "click"
+    TYPE = "type"
+    SCROLL = "scroll"
+    SCREENSHOT = "screenshot"
+    EXTRACT_TEXT = "extract_text"
+    EXTRACT_DOM = "extract_dom"
+    WAIT = "wait"
+    EXECUTE_JS = "execute_js"
+
+
+@dataclass
+class BrowserState:
+    """Snapshot of current browser state."""
+
+    current_url: str | None = None
+    title: str | None = None
+    dom_snapshot: str | None = None
+    screenshot_base64: str | None = None
+    console_logs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BrowserActionResult:
+    """Result for a browser action."""
+
+    action: BrowserAction
+    success: bool
+    data: Any = None
+    error: str | None = None
+    screenshot: str | None = None
+    duration_ms: float | None = None
+
+
+@dataclass
+class SecurityPolicy:
+    """Security policy for browser automation."""
+
+    js_execution: bool = False
+    url_allow_list: list[str] = field(default_factory=list)
+    url_deny_list: list[str] = field(default_factory=list)

--- a/jarvis_core/browser/security.py
+++ b/jarvis_core/browser/security.py
@@ -1,0 +1,61 @@
+"""Security policy handling for browser automation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from jarvis_core.browser.schema import SecurityPolicy
+
+_DEFAULT_ALLOW_LIST = [
+    "pubmed.ncbi.nlm.nih.gov",
+    "ncbi.nlm.nih.gov",
+    "arxiv.org",
+    "doi.org",
+    "europepmc.org",
+    "semanticscholar.org",
+]
+
+
+@dataclass
+class BrowserSecurityManager:
+    """Manage browser security policies."""
+
+    policy: SecurityPolicy
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "BrowserSecurityManager":
+        data = {}
+        if path:
+            data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        policy = SecurityPolicy(
+            js_execution=bool(data.get("js_execution", False)),
+            url_allow_list=list(data.get("url_allow_list", _DEFAULT_ALLOW_LIST)),
+            url_deny_list=list(data.get("url_deny_list", [])),
+        )
+        return cls(policy=policy)
+
+    def check_url(self, url: str) -> bool:
+        """Return True when URL is allowed."""
+        for denied in self.policy.url_deny_list:
+            if denied and denied in url:
+                return False
+        if not self.policy.url_allow_list:
+            return True
+        return any(allowed in url for allowed in self.policy.url_allow_list)
+
+    def check_js_execution(self, script: str) -> tuple[bool, str]:
+        """Return whether JS execution is allowed and message."""
+        if not self.policy.js_execution:
+            return False, "JavaScript execution disabled by security policy."
+        if self._contains_blocked_patterns(script, ["document.cookie", "localStorage", "sessionStorage"]):
+            return False, "Script contains blocked storage access patterns."
+        return True, "Allowed"
+
+    @staticmethod
+    def _contains_blocked_patterns(script: str, patterns: Iterable[str]) -> bool:
+        script_lower = script.lower()
+        return any(pattern.lower() in script_lower for pattern in patterns)

--- a/jarvis_core/browser/subagent.py
+++ b/jarvis_core/browser/subagent.py
@@ -1,0 +1,173 @@
+"""Core implementation for the browser subagent."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import importlib.util
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from jarvis_core.browser.recording import BrowserRecorder, generate_session_id
+from jarvis_core.browser.schema import BrowserAction, BrowserActionResult, BrowserState, SecurityPolicy
+from jarvis_core.browser.security import BrowserSecurityManager
+
+
+@dataclass
+class _PlaywrightSession:
+    playwright: Any
+    browser: Any
+    page: Any
+
+
+class BrowserSubagent:
+    """Playwright-based browser subagent."""
+
+    def __init__(
+        self,
+        security_policy: SecurityPolicy | None = None,
+        headless: bool = True,
+    ) -> None:
+        self.security_manager = BrowserSecurityManager(policy=security_policy or SecurityPolicy())
+        self.headless = headless
+        self.session: _PlaywrightSession | None = None
+        self.state = BrowserState()
+        self.recorder: BrowserRecorder | None = None
+
+    async def initialize(self) -> None:
+        async_playwright = self._load_async_playwright()
+        playwright = await async_playwright().start()
+        browser = await playwright.chromium.launch(headless=self.headless)
+        page = await browser.new_page()
+        self.session = _PlaywrightSession(playwright=playwright, browser=browser, page=page)
+
+    async def navigate(self, url: str) -> BrowserActionResult:
+        start = time.perf_counter()
+        if not self.security_manager.check_url(url):
+            return self._result(
+                BrowserAction.NAVIGATE,
+                False,
+                error=f"URL not allowed by security policy: {url}",
+                duration_ms=self._elapsed_ms(start),
+            )
+        await self._ensure_initialized()
+        await self.session.page.goto(url)
+        await self._refresh_state()
+        await self._capture_recording_frame()
+        return self._result(BrowserAction.NAVIGATE, True, data={"url": url}, duration_ms=self._elapsed_ms(start))
+
+    async def click(self, selector: str) -> BrowserActionResult:
+        start = time.perf_counter()
+        await self._ensure_initialized()
+        await self.session.page.click(selector)
+        await self._refresh_state()
+        await self._capture_recording_frame()
+        return self._result(BrowserAction.CLICK, True, data={"selector": selector}, duration_ms=self._elapsed_ms(start))
+
+    async def type_text(self, selector: str, text: str) -> BrowserActionResult:
+        start = time.perf_counter()
+        await self._ensure_initialized()
+        await self.session.page.fill(selector, text)
+        await self._refresh_state()
+        await self._capture_recording_frame()
+        return self._result(
+            BrowserAction.TYPE,
+            True,
+            data={"selector": selector, "text": text},
+            duration_ms=self._elapsed_ms(start),
+        )
+
+    async def screenshot(self, full_page: bool = False) -> BrowserActionResult:
+        start = time.perf_counter()
+        await self._ensure_initialized()
+        image_bytes = await self.session.page.screenshot(full_page=full_page)
+        encoded = base64.b64encode(image_bytes).decode("utf-8")
+        await self._capture_recording_frame(image_bytes)
+        return self._result(
+            BrowserAction.SCREENSHOT,
+            True,
+            data={"full_page": full_page},
+            screenshot=encoded,
+            duration_ms=self._elapsed_ms(start),
+        )
+
+    async def extract_text(self, selector: str) -> BrowserActionResult:
+        start = time.perf_counter()
+        await self._ensure_initialized()
+        element = await self.session.page.query_selector(selector)
+        text = None
+        if element is not None:
+            text = await element.inner_text()
+        await self._refresh_state()
+        return self._result(
+            BrowserAction.EXTRACT_TEXT,
+            True,
+            data={"selector": selector, "text": text},
+            duration_ms=self._elapsed_ms(start),
+        )
+
+    async def close(self) -> None:
+        if self.session is None:
+            return
+        await self.session.page.close()
+        await self.session.browser.close()
+        await self.session.playwright.stop()
+        self.session = None
+
+    def start_recording(self) -> None:
+        if self.recorder is None:
+            self.recorder = BrowserRecorder(session_id=generate_session_id())
+        self.recorder.start_recording()
+
+    def stop_recording(self) -> str:
+        if self.recorder is None:
+            return str(BrowserRecorder(session_id=generate_session_id()).stop_recording())
+        recording_path = self.recorder.stop_recording()
+        return str(recording_path)
+
+    async def _ensure_initialized(self) -> None:
+        if self.session is None:
+            raise RuntimeError("BrowserSubagent is not initialized. Call initialize() first.")
+
+    async def _refresh_state(self) -> None:
+        if self.session is None:
+            return
+        self.state.current_url = self.session.page.url
+        self.state.title = await self.session.page.title()
+
+    async def _capture_recording_frame(self, image_bytes: bytes | None = None) -> None:
+        if self.recorder is None or not self.recorder.active:
+            return
+        if image_bytes is None:
+            image_bytes = await self.session.page.screenshot(full_page=False)
+        self.recorder.capture_frame(image_bytes)
+
+    def _result(
+        self,
+        action: BrowserAction,
+        success: bool,
+        data: Any = None,
+        error: str | None = None,
+        screenshot: str | None = None,
+        duration_ms: float | None = None,
+    ) -> BrowserActionResult:
+        return BrowserActionResult(
+            action=action,
+            success=success,
+            data=data,
+            error=error,
+            screenshot=screenshot,
+            duration_ms=duration_ms,
+        )
+
+    @staticmethod
+    def _elapsed_ms(start: float) -> float:
+        return (time.perf_counter() - start) * 1000
+
+    @staticmethod
+    def _load_async_playwright():
+        if importlib.util.find_spec("playwright.async_api") is None:
+            raise RuntimeError("playwright is not installed. Install jarvis-research-os[browser].")
+        module = importlib.import_module("playwright.async_api")
+        return module.async_playwright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ web = [
     "uvicorn>=0.22.0",
     "python-multipart>=0.0.6",
 ]
+browser = [
+    "playwright>=1.41.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -82,7 +85,7 @@ dev = [
     "bandit>=1.7.0",
 ]
 all = [
-    "jarvis-research-os[ml,pdf,llm,embedding,web]",
+    "jarvis-research-os[ml,pdf,llm,embedding,web,browser]",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
### Motivation
- Provide a browser automation subagent to enable site navigation, extraction and PDF download workflows for research sources such as PubMed and arXiv.
- Enforce a default security policy and recording capability so automated browsing remains auditable and constrained.
- Make Playwright an optional dependency so consumers can opt into full browser features without breaking core installs.

### Description
- Added browser data schemas at `jarvis_core/browser/schema.py` and package init at `jarvis_core/browser/__init__.py` to define actions, state, results and security policy.
- Implemented a Playwright-backed `BrowserSubagent` with core async actions and optional recording hooks in `jarvis_core/browser/subagent.py` and added recording utilities in `jarvis_core/browser/recording.py`.
- Implemented `BrowserSecurityManager` and a sample `configs/browser_security.yaml` to load allow/deny lists and JS execution policy in `jarvis_core/browser/security.py`.
- Added site-specific agents `PubMedBrowserAgent`, `ArxivBrowserAgent`, and a `PDFDownloadAgent` (with Unpaywall lookup) under `jarvis_core/browser/agents/` and exported them via package `__init__`.
- Marked `playwright>=1.41.0` as an optional `browser` dependency in `pyproject.toml` and included it in the aggregated `all` extras; commits were created per task (Task 019–025).

### Testing
- Ran the automated test command `uv run pytest`, which attempted to create a virtualenv and fetch dependencies but failed due to network/PyPI access errors so the test run could not complete.  
- No test suite results could be reported because dependency installation failed (`Request failed` connecting to `pypi.org`), so further CI/testing should be re-run in an environment with PyPI access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783c2453ec83309acd3059956cf753)