### PR TITLE
Implement Tasks 041–060: Orchestrator approvals, callbacks, agents, rules/workflows, and web APIs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,20 @@
+# Rules Engine
+
+The Rules Engine loads global and workspace rule files and composes them into LLM context.
+
+## Global Rules
+Global rules live at `~/.gemini/GEMINI.md`. They define baseline expectations for code style,
+documentation, and testing across projects.
+
+## Workspace Rules
+Workspace rules live inside `<workspace>/.agent/rules/*.md`. These files allow a specific
+repository to override or extend the global rules.
+
+## Rule Loading Behavior
+- Rules are discovered at startup by the Rules Engine.
+- Workspace rules override global rules when the rule name matches.
+- All enabled rules are concatenated into a single context string for the LLM.
+
+## Template Files
+- `templates/GEMINI.md` provides the default global rules template.
+- `templates/workspace_rules/` contains sample workspace rule files.

--- a/jarvis_core/orchestrator/agents/__init__.py
+++ b/jarvis_core/orchestrator/agents/__init__.py
@@ -1,0 +1,9 @@
+"""Agent implementations for the orchestrator."""
+
+from .browser import BrowserAgent
+from .research import ResearchAgent
+
+__all__ = [
+    "BrowserAgent",
+    "ResearchAgent",
+]

--- a/jarvis_core/orchestrator/agents/browser.py
+++ b/jarvis_core/orchestrator/agents/browser.py
@@ -1,0 +1,62 @@
+"""Browser agent implementation."""
+from __future__ import annotations
+
+import base64
+import re
+
+from jarvis_core.browser.subagent import BrowserSubagent
+from jarvis_core.orchestrator.artifact_store import ArtifactStore
+from jarvis_core.orchestrator.multi_agent import MultiAgentOrchestrator
+from jarvis_core.orchestrator.schema import AgentTask
+
+
+class BrowserAgent:
+    """Agent that performs browser-based tasks."""
+
+    URL_PATTERN = re.compile(r"https?://\S+")
+
+    async def execute(self, task: AgentTask, orchestrator: MultiAgentOrchestrator) -> None:
+        agent_id = orchestrator.find_agent_id(task.task_id) or task.task_id
+        store = ArtifactStore()
+        url = self._extract_url(task.description)
+
+        if not url:
+            message = f"No URL found in task description: {task.description}"
+            path = store.save(agent_id, "extracted_text.txt", message)
+            await orchestrator.record_artifact(agent_id, path)
+            return
+
+        subagent = BrowserSubagent(headless=True)
+        subagent.start_recording()
+        await subagent.initialize()
+        try:
+            await subagent.navigate(url)
+            screenshot_result = await subagent.screenshot(full_page=True)
+            text_result = await subagent.extract_text("body")
+        finally:
+            recording_dir = subagent.stop_recording()
+            await subagent.close()
+
+        if screenshot_result.screenshot:
+            image_bytes = base64.b64decode(screenshot_result.screenshot)
+            screenshot_path = store.save(agent_id, "screenshot.png", image_bytes)
+            await orchestrator.record_artifact(agent_id, screenshot_path)
+
+        extracted_text = text_result.data.get("text") if text_result.data else None
+        text_content = extracted_text or ""
+        text_path = store.save(agent_id, "extracted_text.txt", text_content)
+        await orchestrator.record_artifact(agent_id, text_path)
+
+        if subagent.recorder:
+            for index, frame_path in enumerate(subagent.recorder.list_frames(), start=1):
+                frame_bytes = frame_path.read_bytes()
+                filename = f"recording_frame_{index:04d}.png"
+                saved_path = store.save(agent_id, filename, frame_bytes)
+                await orchestrator.record_artifact(agent_id, saved_path)
+
+    @classmethod
+    def _extract_url(cls, text: str) -> str | None:
+        match = cls.URL_PATTERN.search(text)
+        if not match:
+            return None
+        return match.group(0)

--- a/jarvis_core/orchestrator/agents/research.py
+++ b/jarvis_core/orchestrator/agents/research.py
@@ -1,0 +1,48 @@
+"""Research agent implementation."""
+from __future__ import annotations
+
+import asyncio
+
+from jarvis_core import run_jarvis
+from jarvis_core.orchestrator.artifact_store import ArtifactStore
+from jarvis_core.orchestrator.multi_agent import MultiAgentOrchestrator
+from jarvis_core.orchestrator.schema import AgentTask
+
+
+class ResearchAgent:
+    """Agent that runs literature research tasks."""
+
+    async def execute(self, task: AgentTask, orchestrator: MultiAgentOrchestrator) -> None:
+        agent_id = orchestrator.find_agent_id(task.task_id) or task.task_id
+        store = ArtifactStore()
+
+        task_plan = """# Task Plan
+
+1. Clarify the research goal.
+2. Identify key keywords and sources.
+3. Gather and summarize evidence.
+"""
+        implementation_plan = """# Implementation Plan
+
+- Execute the research plan in stages.
+- Capture findings and citations.
+- Summarize outputs for downstream use.
+"""
+
+        result = await asyncio.to_thread(run_jarvis, task.description)
+        walkthrough = """# Walkthrough
+
+## Goal
+{goal}
+
+## Result
+{result}
+""".format(goal=task.description, result=result)
+
+        for filename, content in (
+            ("task_plan.md", task_plan),
+            ("implementation_plan.md", implementation_plan),
+            ("walkthrough.md", walkthrough),
+        ):
+            path = store.save(agent_id, filename, content)
+            await orchestrator.record_artifact(agent_id, path)

--- a/jarvis_core/orchestrator/artifact_store.py
+++ b/jarvis_core/orchestrator/artifact_store.py
@@ -1,0 +1,36 @@
+"""Artifact storage for orchestrator agents."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ArtifactStore:
+    """Save and load agent artifacts under logs/artifacts."""
+
+    def __init__(self, base_dir: Path | str = Path("logs/artifacts")) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def save(self, agent_id: str, filename: str, content: str | bytes) -> str:
+        agent_dir = self.base_dir / agent_id
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path = agent_dir / filename
+        if isinstance(content, bytes):
+            artifact_path.write_bytes(content)
+        else:
+            artifact_path.write_text(content, encoding="utf-8")
+        return str(artifact_path)
+
+    def load(self, artifact_path: str) -> str | bytes:
+        path = Path(artifact_path)
+        data = path.read_bytes()
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return data
+
+    def list_artifacts(self, agent_id: str) -> list[str]:
+        agent_dir = self.base_dir / agent_id
+        if not agent_dir.exists():
+            return []
+        return [str(path) for path in sorted(agent_dir.iterdir()) if path.is_file()]

--- a/jarvis_core/rules/__init__.py
+++ b/jarvis_core/rules/__init__.py
@@ -1,0 +1,10 @@
+"""Rules engine package."""
+
+from .engine import RulesEngine
+from .schema import Rule, RuleScope
+
+__all__ = [
+    "RulesEngine",
+    "Rule",
+    "RuleScope",
+]

--- a/jarvis_core/rules/engine.py
+++ b/jarvis_core/rules/engine.py
@@ -1,0 +1,65 @@
+"""Rules engine for global and workspace rules."""
+from __future__ import annotations
+
+import textwrap
+from dataclasses import asdict
+from pathlib import Path
+
+from .schema import Rule, RuleScope
+
+
+class RulesEngine:
+    """Load and provide rules for LLM context."""
+
+    def __init__(self, workspace_path: Path | None) -> None:
+        self.workspace_path = Path(workspace_path) if workspace_path else None
+        self._rules: dict[str, Rule] = {}
+        self._loaded = False
+
+    def load_rules(self) -> None:
+        if self._loaded:
+            return
+        self._rules.clear()
+        global_path = Path("~/.gemini/GEMINI.md").expanduser()
+        if global_path.exists():
+            rule = Rule(
+                name=global_path.stem,
+                scope=RuleScope.GLOBAL,
+                path=global_path,
+                content=global_path.read_text(encoding="utf-8"),
+                enabled=True,
+            )
+            self._rules[rule.name] = rule
+        if self.workspace_path:
+            workspace_dir = self.workspace_path / ".agent" / "rules"
+            if workspace_dir.exists():
+                for rule_path in sorted(workspace_dir.glob("*.md")):
+                    rule = Rule(
+                        name=rule_path.stem,
+                        scope=RuleScope.WORKSPACE,
+                        path=rule_path,
+                        content=rule_path.read_text(encoding="utf-8"),
+                        enabled=True,
+                    )
+                    self._rules[rule.name] = rule
+        self._loaded = True
+
+    def get_context_for_llm(self) -> str:
+        self.load_rules()
+        sections = []
+        for rule in self._rules.values():
+            if not rule.enabled:
+                continue
+            header = f"## Rule: {rule.name} ({rule.scope.value})"
+            sections.append("\n".join([header, rule.content.strip()]))
+        return textwrap.dedent("\n\n".join(sections)).strip()
+
+    def list_rules(self) -> list[dict]:
+        self.load_rules()
+        output = []
+        for rule in self._rules.values():
+            data = asdict(rule)
+            data["scope"] = rule.scope.value
+            data["path"] = str(rule.path)
+            output.append(data)
+        return sorted(output, key=lambda item: item.get("name", ""))

--- a/jarvis_core/rules/schema.py
+++ b/jarvis_core/rules/schema.py
@@ -1,0 +1,24 @@
+"""Rules schema definitions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class RuleScope(str, Enum):
+    """Scope for a rule file."""
+
+    GLOBAL = "global"
+    WORKSPACE = "workspace"
+
+
+@dataclass
+class Rule:
+    """Rule definition loaded from disk."""
+
+    name: str
+    scope: RuleScope
+    path: Path
+    content: str
+    enabled: bool = True

--- a/jarvis_core/workflows/__init__.py
+++ b/jarvis_core/workflows/__init__.py
@@ -6,10 +6,18 @@ from .canonical import (
     run_plan_to_paper,
     run_plan_to_talk,
 )
+from .engine import WorkflowsEngine
+from .schema import Workflow, WorkflowMetadata, WorkflowScope
+from .slash_command import parse_slash_command
 
 __all__ = [
     "run_literature_to_plan",
     "run_plan_to_grant",
     "run_plan_to_paper",
     "run_plan_to_talk",
+    "WorkflowsEngine",
+    "Workflow",
+    "WorkflowMetadata",
+    "WorkflowScope",
+    "parse_slash_command",
 ]

--- a/jarvis_core/workflows/builtin/meta-analysis.md
+++ b/jarvis_core/workflows/builtin/meta-analysis.md
@@ -1,0 +1,13 @@
+---
+name: meta-analysis
+description: Meta-analysis workflow
+command: /meta-analysis
+---
+# Meta-Analysis Workflow
+
+1. 効果量の抽出
+2. 異質性の評価（I², Q統計量）
+3. 固定/ランダム効果モデルの選択
+4. プール効果量の計算
+5. Forest plotの生成
+6. 出版バイアスの評価

--- a/jarvis_core/workflows/builtin/systematic-review.md
+++ b/jarvis_core/workflows/builtin/systematic-review.md
@@ -1,0 +1,14 @@
+---
+name: systematic-review
+description: Systematic literature review workflow
+command: /systematic-review
+---
+# Systematic Review Workflow
+
+1. PICO形式で研究質問を定義
+2. 検索戦略を構築
+3. データベースを検索
+4. スクリーニング実施
+5. エビデンスグレーディング
+6. PRISMAフロー生成
+7. 統合レポート作成

--- a/jarvis_core/workflows/engine.py
+++ b/jarvis_core/workflows/engine.py
@@ -1,0 +1,112 @@
+"""Workflows engine for discovery and execution."""
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .schema import Workflow, WorkflowMetadata, WorkflowScope
+
+
+class WorkflowsEngine:
+    """Discover and execute saved workflows."""
+
+    def __init__(self, workspace_path: Path | None) -> None:
+        self.workspace_path = Path(workspace_path) if workspace_path else None
+        self._workflows: dict[str, Workflow] = {}
+        self._discovered = False
+
+    def discover_workflows(self) -> None:
+        if self._discovered:
+            return
+        for scope, base_dir in self._workflow_dirs():
+            if not base_dir.exists():
+                continue
+            for workflow_file in sorted(base_dir.rglob("*.md")):
+                metadata, body = self._parse_workflow_file(workflow_file)
+                workflow = Workflow(
+                    metadata=metadata,
+                    scope=scope,
+                    path=workflow_file,
+                    content=body,
+                )
+                self._workflows[metadata.name] = workflow
+        self._discovered = True
+
+    def get_workflow(self, name: str) -> Workflow | None:
+        self.discover_workflows()
+        return self._workflows.get(name)
+
+    def list_workflows(self) -> list[dict]:
+        self.discover_workflows()
+        output = []
+        for workflow in self._workflows.values():
+            data = asdict(workflow.metadata)
+            data.update({
+                "scope": workflow.scope.value,
+                "path": str(workflow.path),
+            })
+            output.append(data)
+        return sorted(output, key=lambda item: item.get("name", ""))
+
+    def execute(self, name: str, context: dict) -> str:
+        workflow = self.get_workflow(name)
+        if not workflow:
+            raise ValueError(f"Workflow not found: {name}")
+        payload = json.dumps(context, ensure_ascii=False, indent=2)
+        execution = """# Workflow Execution
+
+## Workflow
+{workflow_name}
+
+## Description
+{description}
+
+## Context
+{context}
+
+## Steps
+{steps}
+""".format(
+            workflow_name=workflow.metadata.name,
+            description=workflow.metadata.description,
+            context=payload,
+            steps=workflow.content.strip(),
+        )
+        return textwrap.dedent(execution).strip()
+
+    def _workflow_dirs(self) -> list[tuple[WorkflowScope, Path]]:
+        dirs = [
+            (WorkflowScope.GLOBAL, Path("~/.gemini/antigravity/global_workflows").expanduser()),
+            (WorkflowScope.GLOBAL, Path(__file__).parent / "builtin"),
+        ]
+        if self.workspace_path:
+            dirs.append((WorkflowScope.WORKSPACE, self.workspace_path / ".agent" / "workflows"))
+        return dirs
+
+    @staticmethod
+    def _parse_workflow_file(path: Path) -> tuple[WorkflowMetadata, str]:
+        content = path.read_text(encoding="utf-8")
+        frontmatter: dict[str, Any] = {}
+        body = content
+        lines = content.splitlines()
+        if lines and lines[0].strip() == "---":
+            end_index = None
+            for idx in range(1, len(lines)):
+                if lines[idx].strip() == "---":
+                    end_index = idx
+                    break
+            if end_index is not None:
+                frontmatter_text = "\n".join(lines[1:end_index])
+                frontmatter = yaml.safe_load(frontmatter_text) or {}
+                body = "\n".join(lines[end_index + 1 :]).lstrip()
+        metadata = WorkflowMetadata(
+            name=str(frontmatter.get("name") or path.stem),
+            description=str(frontmatter.get("description") or ""),
+            command=str(frontmatter.get("command") or ""),
+        )
+        return metadata, body

--- a/jarvis_core/workflows/schema.py
+++ b/jarvis_core/workflows/schema.py
@@ -1,0 +1,32 @@
+"""Workflow schema definitions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class WorkflowScope(str, Enum):
+    """Scope for a workflow definition."""
+
+    GLOBAL = "global"
+    WORKSPACE = "workspace"
+
+
+@dataclass
+class WorkflowMetadata:
+    """Metadata for workflow frontmatter."""
+
+    name: str
+    description: str
+    command: str
+
+
+@dataclass
+class Workflow:
+    """Loaded workflow definition."""
+
+    metadata: WorkflowMetadata
+    scope: WorkflowScope
+    path: Path
+    content: str

--- a/jarvis_core/workflows/slash_command.py
+++ b/jarvis_core/workflows/slash_command.py
@@ -1,0 +1,14 @@
+"""Slash command parser for workflows."""
+from __future__ import annotations
+
+
+def parse_slash_command(input_text: str) -> tuple[str | None, str]:
+    stripped = input_text.strip()
+    if not stripped.startswith("/"):
+        return None, input_text
+    parts = stripped.split(maxsplit=1)
+    command = parts[0][1:]
+    if not command:
+        return None, input_text
+    remaining = parts[1] if len(parts) > 1 else ""
+    return command, remaining

--- a/jarvis_web/api/__init__.py
+++ b/jarvis_web/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routers for JARVIS web."""

--- a/jarvis_web/api/inbox.py
+++ b/jarvis_web/api/inbox.py
@@ -1,0 +1,62 @@
+"""Inbox API endpoints."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from jarvis_web.api.orchestrator import _ensure_started, _get_orchestrator
+
+
+router = APIRouter(prefix="/api", tags=["inbox"])
+
+
+class ConversationCreateRequest(BaseModel):
+    title: str
+    workspace: str
+
+
+class MessageCreateRequest(BaseModel):
+    agent_id: str
+    role: str
+    content: str
+    artifacts: list[str] | None = None
+
+
+@router.get("/inbox")
+async def get_inbox() -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    return {"inbox": orchestrator.get_inbox()}
+
+
+@router.post("/conversations")
+async def create_conversation(payload: ConversationCreateRequest) -> dict[str, Any]:
+    orchestrator = await _ensure_started()
+    conversation_id = orchestrator.create_conversation(payload.title, payload.workspace)
+    return {"conversation_id": conversation_id}
+
+
+@router.get("/conversations/{conversation_id}")
+async def get_conversation(conversation_id: str) -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    conversation = orchestrator.get_conversation(conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="conversation_not_found")
+    return {"conversation": conversation}
+
+
+@router.post("/conversations/{conversation_id}/messages")
+async def add_message(conversation_id: str, payload: MessageCreateRequest) -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    try:
+        message_id = orchestrator.add_message(
+            conversation_id,
+            agent_id=payload.agent_id,
+            role=payload.role,
+            content=payload.content,
+            artifacts=payload.artifacts,
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="conversation_not_found")
+    return {"message_id": message_id}

--- a/jarvis_web/api/mcp.py
+++ b/jarvis_web/api/mcp.py
@@ -1,0 +1,57 @@
+"""MCP API endpoints."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from jarvis_core.mcp.hub import MCPHub
+
+
+router = APIRouter(prefix="/api/mcp", tags=["mcp"])
+
+
+class ToolInvokeRequest(BaseModel):
+    params: dict[str, Any] = {}
+
+
+_hub: MCPHub | None = None
+
+
+def _get_hub() -> MCPHub:
+    global _hub
+    if _hub is None:
+        hub = MCPHub()
+        config_path = Path("configs/mcp_config.json")
+        if config_path.exists():
+            hub.register_from_config(str(config_path))
+        _hub = hub
+    return _hub
+
+
+@router.get("/servers")
+async def list_servers() -> dict[str, Any]:
+    hub = _get_hub()
+    return {"servers": hub.list_servers()}
+
+
+@router.get("/tools")
+async def list_tools() -> dict[str, Any]:
+    hub = _get_hub()
+    return {"tools": hub.list_all_tools()}
+
+
+@router.post("/tools/{tool_name}/invoke")
+async def invoke_tool(tool_name: str, payload: ToolInvokeRequest) -> dict[str, Any]:
+    hub = _get_hub()
+    result = await hub.invoke_tool(tool_name, payload.params)
+    return {"result": result.__dict__}
+
+
+@router.post("/discover/{server_name}")
+async def discover_tools(server_name: str) -> dict[str, Any]:
+    hub = _get_hub()
+    tools = await hub.discover_tools(server_name)
+    return {"tools": [tool.__dict__ for tool in tools]}

--- a/jarvis_web/api/orchestrator.py
+++ b/jarvis_web/api/orchestrator.py
@@ -1,0 +1,89 @@
+"""Orchestrator API endpoints."""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from jarvis_core.orchestrator.multi_agent import MultiAgentOrchestrator
+from jarvis_core.orchestrator.schema import AgentMode, AgentTask
+
+
+router = APIRouter(prefix="/api", tags=["orchestrator"])
+
+
+class SpawnAgentRequest(BaseModel):
+    description: str
+    agent_type: str
+    priority: int = 0
+    dependencies: list[str] = []
+    mode: str | None = None
+    conversation_id: str | None = None
+
+
+class ApprovalRequest(BaseModel):
+    approved: bool
+
+
+_orchestrator: MultiAgentOrchestrator | None = None
+
+
+def _get_orchestrator() -> MultiAgentOrchestrator:
+    global _orchestrator
+    if _orchestrator is None:
+        _orchestrator = MultiAgentOrchestrator(max_concurrent_agents=3, default_mode=AgentMode.PLANNING)
+    return _orchestrator
+
+
+async def _ensure_started() -> MultiAgentOrchestrator:
+    orchestrator = _get_orchestrator()
+    await orchestrator.start()
+    return orchestrator
+
+
+@router.post("/agents/spawn")
+async def spawn_agent(payload: SpawnAgentRequest) -> dict[str, Any]:
+    orchestrator = await _ensure_started()
+    task = AgentTask(
+        task_id=str(uuid.uuid4()),
+        description=payload.description,
+        agent_type=payload.agent_type,
+        priority=payload.priority,
+        dependencies=payload.dependencies,
+    )
+    mode = AgentMode(payload.mode) if payload.mode else None
+    agent_id = await orchestrator.spawn_agent(task, mode=mode, conversation_id=payload.conversation_id)
+    return {"agent_id": agent_id}
+
+
+@router.get("/agents")
+async def list_agents() -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    return {"agents": orchestrator.get_all_agents()}
+
+
+@router.get("/agents/{agent_id}")
+async def get_agent(agent_id: str) -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    status = orchestrator.get_agent_status(agent_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="agent_not_found")
+    return {"agent": status}
+
+
+@router.post("/agents/{agent_id}/approve")
+async def approve_agent(agent_id: str, payload: ApprovalRequest) -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    await orchestrator.approve(agent_id, approved=payload.approved)
+    status = orchestrator.get_agent_status(agent_id)
+    return {"agent": status}
+
+
+@router.post("/agents/{agent_id}/cancel")
+async def cancel_agent(agent_id: str) -> dict[str, Any]:
+    orchestrator = _get_orchestrator()
+    await orchestrator.approve(agent_id, approved=False)
+    status = orchestrator.get_agent_status(agent_id)
+    return {"agent": status}

--- a/jarvis_web/api/ws.py
+++ b/jarvis_web/api/ws.py
@@ -1,0 +1,46 @@
+"""WebSocket endpoints for agent progress."""
+from __future__ import annotations
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from jarvis_web.api.orchestrator import _ensure_started
+
+
+router = APIRouter()
+
+
+@router.websocket("/ws/agents/{agent_id}")
+async def agent_progress(websocket: WebSocket, agent_id: str) -> None:
+    await websocket.accept()
+    orchestrator = await _ensure_started()
+
+    async def send_event(event_type: str, payload: dict) -> None:
+        if payload.get("agent_id") != agent_id:
+            return
+        try:
+            await websocket.send_json({"event": event_type, "data": payload})
+        except WebSocketDisconnect:
+            return
+
+    async def status_callback(payload: dict) -> None:
+        await send_event("status_change", payload)
+
+    async def progress_callback(payload: dict) -> None:
+        await send_event("progress_update", payload)
+
+    async def artifact_callback(payload: dict) -> None:
+        await send_event("artifact_created", payload)
+
+    async def approval_callback(payload: dict) -> None:
+        await send_event("approval_required", payload)
+
+    orchestrator.register_callback("status_change", status_callback)
+    orchestrator.register_callback("progress_update", progress_callback)
+    orchestrator.register_callback("artifact_created", artifact_callback)
+    orchestrator.register_callback("approval_required", approval_callback)
+
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        return

--- a/jarvis_web/app.py
+++ b/jarvis_web/app.py
@@ -52,6 +52,10 @@ API_MAP_PATH = Path("jarvis_web/contracts/api_map_v1.json")
 # Create app if FastAPI available
 if FASTAPI_AVAILABLE:
     from jarvis_web.auth import verify_api_token, verify_token
+    from jarvis_web.api.mcp import router as mcp_router
+    from jarvis_web.api.inbox import router as inbox_router
+    from jarvis_web.api.orchestrator import router as orchestrator_router
+    from jarvis_web.api.ws import router as ws_router
     from jarvis_web.routes.research import router as research_router
     # from jarvis_web.routes.finance import router as finance_router (Moved to lazy import)
     from jarvis_web.routes.schedules import router as schedules_router
@@ -98,6 +102,10 @@ if FASTAPI_AVAILABLE:
     app.include_router(schedules_router)
     app.include_router(cron_router)
     app.include_router(queue_router)
+    app.include_router(mcp_router)
+    app.include_router(orchestrator_router)
+    app.include_router(inbox_router)
+    app.include_router(ws_router)
     if submission_router:
         app.include_router(submission_router)
 else:

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -1,0 +1,16 @@
+# Global Rules (GEMINI)
+
+## Code Style Guidelines
+- Follow existing project formatting and naming conventions.
+- Prefer small, composable functions with clear responsibilities.
+- Document any non-obvious behavior inline with comments.
+
+## Documentation Requirements
+- Update relevant markdown docs when behavior changes.
+- Include usage examples for new workflows or rules.
+- Keep references to external systems accurate and current.
+
+## Testing Standards
+- Run the full test suite before release.
+- Add tests for any new core logic or user-facing behavior.
+- Record known limitations in the changelog.

--- a/templates/workspace_rules/code-style.md
+++ b/templates/workspace_rules/code-style.md
@@ -1,0 +1,5 @@
+# Workspace Code Style Rules
+
+- Use project-specific naming conventions for modules and functions.
+- Prefer explicit types in public APIs where applicable.
+- Keep functions under 50 lines unless a longer block is justified.

--- a/templates/workspace_rules/evidence-rules.md
+++ b/templates/workspace_rules/evidence-rules.md
@@ -1,0 +1,5 @@
+# Workspace Evidence Rules
+
+- Every factual claim must include an evidence identifier.
+- Summaries must note uncertainty when evidence is weak.
+- Use consistent citation formatting across documents.

--- a/templates/workspace_rules/language-rules.md
+++ b/templates/workspace_rules/language-rules.md
@@ -1,0 +1,5 @@
+# Workspace Language Rules
+
+- Avoid absolute causal language without strong evidence.
+- Use hedging language when discussing preliminary findings.
+- Keep summaries concise and structured.


### PR DESCRIPTION
### Motivation
- Implement orchestrator approval and callback flows, artifact management, agent dispatch and progress updates to meet the multi-agent orchestration requirements in Tasks 041–046 and 060.
- Provide rule/workflow discovery, builtin templates, and CLI support so LLM context and saved workflows can be managed (Tasks 046–056).
- Expose MCP, orchestrator, inbox, and real-time progress APIs so external systems and UIs can interact with the orchestrator (Tasks 057–060).

### Description
- Extended `MultiAgentOrchestrator` to use `asyncio.Queue` for task queuing and added approval flow (`request_approval`, `approve`), callback registration `register_callback`, status/progress event emission, artifact recording, and agent dispatching in `jarvis_core/orchestrator/multi_agent.py`.
- Added `ArtifactStore` plus `ResearchAgent` and `BrowserAgent` implementations that save artifacts and report them back to the orchestrator under `jarvis_core/orchestrator/`.
- Implemented Rules and Workflows subsystems with schemas and engines (`jarvis_core/rules/*`, `jarvis_core/workflows/*`), provided templates in `templates/` and docs `docs/rules.md`, and added CLI commands integrating them into `jarvis_cli.py`.
- Added FastAPI routers for MCP, orchestrator, inbox, and WebSocket progress notifications in `jarvis_web/api/` and wired the routers into `jarvis_web/app.py` for REST and real-time event delivery.

### Testing
- Ran the full test command `uv run pytest`, but the run failed during environment setup due to a network/PyPI fetch error for the `rank-bm25` package, so the full test suite could not be completed. 
- Local smoke checks for the orchestrator queue/approval flow and basic workflow discovery were exercised during development and behaved as expected (no automated test failures produced by the local checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784392c9bc8330944bd14f93739b26)