### PR TITLE
Add daily coverage snapshot scripts and coverage_daily.md

### DIFF
--- a/docs/coverage_daily.md
+++ b/docs/coverage_daily.md
@@ -1,0 +1,20 @@
+# Daily Coverage Snapshot
+
+> **Authority**: REFERENCE (Level 4, Non-binding)  
+> **Purpose**: 毎日1回のカバレッジ計測結果を時系列で蓄積する  
+> **Timezone**: Asia/Tokyo（JST）
+
+---
+
+## 運用ルール
+
+1. このファイルは自動更新される（手動編集禁止）
+2. 数値を盛る目的の除外は`COVERAGE_POLICY.md`で禁止されている
+3. 急激な低下（前日比-5%以上）が発生した場合はSlack通知（将来実装）
+
+---
+
+## Log
+
+<!-- newest entries are appended at the end -->
+<!-- DO NOT EDIT MANUALLY -->

--- a/scripts/append_coverage_daily_md.py
+++ b/scripts/append_coverage_daily_md.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Append daily coverage snapshot to docs/coverage_daily.md
+
+Usage:
+    python scripts/append_coverage_daily_md.py \
+        --md docs/coverage_daily.md \
+        --report artifacts/coverage_daily_term.txt
+
+Environment Variables:
+    COVERAGE_PHASE: 1 or 2 (default: 1)
+    GITHUB_SHA: commit SHA (from GitHub Actions)
+    GITHUB_REPOSITORY: owner/repo (from GitHub Actions)
+    GITHUB_RUN_ID: workflow run ID (from GitHub Actions)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+
+TOTAL_RE = re.compile(r"^TOTAL\s+\d+\s+\d+\s+(\d+)%\s*$", re.MULTILINE)
+TOTAL_RE_BRANCH = re.compile(
+    r"^TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)%\s*$", re.MULTILINE
+)
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """Immutable snapshot data."""
+
+    date_jst: str
+    phase: str
+    total_pct: str
+    commit_sha: str
+    run_url: str
+    notes: str = ""
+
+
+if __name__ == "__main__":
+    print("Script structure OK")

--- a/scripts/daily_coverage_snapshot.sh
+++ b/scripts/daily_coverage_snapshot.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Daily Coverage Snapshot (non-gating)
+# Purpose: 測定のみ行い、fail_underでブロックしない
+# Usage: COVERAGE_PHASE=1 bash scripts/daily_coverage_snapshot.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PHASE="${COVERAGE_PHASE:-1}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts}"
+
+# Phase validation
+if [[ "$PHASE" != "1" && "$PHASE" != "2" ]]; then
+    echo "ERROR: Invalid COVERAGE_PHASE=$PHASE (use 1 or 2)" >&2
+    exit 2
+fi
+
+# Config selection
+if [[ "$PHASE" == "1" ]]; then
+    CFG=".coveragerc.phase1"
+else
+    CFG=".coveragerc.phase2"
+fi
+
+# Config existence check
+if [[ ! -f "$CFG" ]]; then
+    echo "ERROR: Config file not found: $CFG" >&2
+    exit 1
+fi
+
+echo "=== Daily Coverage Snapshot ==="
+echo "Date: $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M:%S JST')"
+echo "Phase: $PHASE"
+echo "Config: $CFG"
+echo "==============================="
+
+# Prepare artifacts directory
+mkdir -p "$ARTIFACTS_DIR"
+
+# Clean up existing coverage files
+rm -f .coverage .coverage.* 2>/dev/null || true
+
+# Run pytest with coverage (ignore test failures for snapshot)
+echo ""
+echo "Running tests with coverage..."
+set +e
+python -m pytest \
+    --cov=jarvis_core \
+    --cov-config="$CFG" \
+    --cov-report=xml \
+    --cov-report=html \
+    --cov-report=term-missing \
+    -q \
+    2>&1 | tee "$ARTIFACTS_DIR/pytest_output.txt"
+PYTEST_EXIT=$?
+set -e
+
+echo ""
+echo "Pytest exit code: $PYTEST_EXIT (ignored for snapshot)"
+
+# Combine parallel coverage files if any
+if ls .coverage.* 1>/dev/null 2>&1; then
+    echo "Combining coverage data..."
+    python -m coverage combine --rcfile="$CFG" 2>/dev/null || true
+fi
+
+echo ""
+echo "=== Coverage Report (non-gating) ==="
+
+# Create temporary config without fail_under
+TEMP_CFG=$(mktemp)
+grep -v "^fail_under" "$CFG" > "$TEMP_CFG" || cp "$CFG" "$TEMP_CFG"
+
+# Generate report
+python -m coverage report --rcfile="$TEMP_CFG" 2>&1 | tee "$ARTIFACTS_DIR/coverage_daily_term.txt"
+
+# Cleanup temp config
+rm -f "$TEMP_CFG"
+
+# Move artifacts
+mv coverage.xml "$ARTIFACTS_DIR/" 2>/dev/null || true
+mv htmlcov "$ARTIFACTS_DIR/" 2>/dev/null || true
+
+echo ""
+echo "=== Snapshot Complete ==="
+echo "Artifacts saved to: $ARTIFACTS_DIR/"
+
+# Always exit 0 (this is snapshot, not gate)
+exit 0


### PR DESCRIPTION
### Motivation

- Implement the Daily Coverage Snapshot flow described in `docs/DAILY_COVERAGE_TASKS.md` so coverage snapshots can be collected and recorded daily.  
- Provide a persistent log template for storing daily snapshots.  
- Add a scaffold for the MD-append helper so automation can record snapshots into the log.

### Description

- Add `docs/coverage_daily.md` containing the required header, operation rules, and a `## Log` section for appended snapshots.  
- Add `scripts/daily_coverage_snapshot.sh` implementing phase selection, pytest invocation (non-gating), combining parallel coverage data, generating a coverage report, moving artifacts to `artifacts/`, and always exiting `0` for snapshot mode.  
- Add `scripts/append_coverage_daily_md.py` initial scaffold (Task 5) including `Snapshot` dataclass and basic parsing regexes and print-on-run behavior.  
- Ensure `scripts/daily_coverage_snapshot.sh` is executable (`chmod +x`).

### Testing

- Ran `bash scripts/daily_coverage_snapshot.sh`, which executed and printed the snapshot header and ran tests, but the coverage reporting step failed due to the environment missing the `coverage` module and `pytest` reported unrecognized coverage args, so full report generation did not complete.  
- Ran `python scripts/append_coverage_daily_md.py`, which succeeded and printed `Script structure OK` as expected.  
- Files were staged and committed as part of the change set (new files: `docs/coverage_daily.md`, `scripts/daily_coverage_snapshot.sh`, `scripts/append_coverage_daily_md.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978981b37148330b6af8427abb0982e)