### PR TITLE
Add daily coverage snapshot tooling: append script, workflow, and policy note

### DIFF
--- a/.github/workflows/coverage-daily.yml
+++ b/.github/workflows/coverage-daily.yml
@@ -1,0 +1,116 @@
+name: Daily Coverage Snapshot
+
+on:
+  schedule:
+    - cron: "10 15 * * *"
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: "Coverage phase (1 or 2)"
+        required: false
+        default: "1"
+      notes:
+        description: "Optional notes for this snapshot"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coverage-daily
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.11"
+  ARTIFACTS_DIR: "artifacts"
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: |
+          uv sync --dev
+          uv pip install coverage[toml]
+
+      - name: Prepare artifacts directory
+        run: mkdir -p ${{ env.ARTIFACTS_DIR }}
+
+      - name: Run daily coverage snapshot
+        env:
+          COVERAGE_PHASE: ${{ github.event.inputs.phase || '1' }}
+          ARTIFACTS_DIR: ${{ env.ARTIFACTS_DIR }}
+        run: |
+          chmod +x scripts/daily_coverage_snapshot.sh
+          bash scripts/daily_coverage_snapshot.sh
+
+      - name: Append result to docs/coverage_daily.md
+        env:
+          COVERAGE_PHASE: ${{ github.event.inputs.phase || '1' }}
+        run: |
+          python scripts/append_coverage_daily_md.py \
+            --md docs/coverage_daily.md \
+            --report ${{ env.ARTIFACTS_DIR }}/coverage_daily_term.txt \
+            --phase "$COVERAGE_PHASE" \
+            --notes "${{ github.event.inputs.notes || '' }}"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet docs/coverage_daily.md; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/coverage_daily.md
+          git commit -m "chore(coverage): daily snapshot $(TZ=Asia/Tokyo date '+%Y-%m-%d') [skip ci]"
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push && break
+            echo "Push failed, retrying ($i/3)..."
+            sleep 5
+          done
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-daily-${{ github.run_id }}
+          path: |
+            ${{ env.ARTIFACTS_DIR }}/coverage_daily_term.txt
+            ${{ env.ARTIFACTS_DIR }}/coverage.xml
+            ${{ env.ARTIFACTS_DIR }}/htmlcov/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Summary
+        run: |
+          echo "## Daily Coverage Snapshot" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Date: $(TZ=Asia/Tokyo date '+%Y-%m-%d')" >> $GITHUB_STEP_SUMMARY
+          echo "Phase: ${{ github.event.inputs.phase || '1' }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -20 ${{ env.ARTIFACTS_DIR }}/coverage_daily_term.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/docs/COVERAGE_POLICY.md
+++ b/docs/COVERAGE_POLICY.md
@@ -113,3 +113,32 @@ PR毎に`docs/coverage_improvement_history.md`に以下を記録:
 
 - [DECISIONS.md](./DECISIONS.md) - DEC-007: 2段階カバレッジゲート
 - [coverage_improvement_history.md](./coverage_improvement_history.md) - 改善履歴
+
+---
+
+## Daily Coverage Snapshotとの役割分担
+
+### 目的の違い
+
+| 観点 | CIゲート（本ポリシー） | Daily Snapshot |
+|------|------------------------|----------------|
+| 目的 | PRの品質担保 | 継続的な観測・トレンド把握 |
+| 実行タイミング | PR/push時 | 毎日00:10 JST |
+| fail_under | 有効（85%/95%） | 無効 |
+| 失敗時 | CIブロック | ログ記録のみ |
+
+### 参照ドキュメント
+
+- 詳細仕様: `docs/JAVIS_STATE_AND_ROADMAP.md` セクション8
+- 実装: `scripts/daily_coverage_snapshot.sh`, `scripts/append_coverage_daily_md.py`
+- 履歴: `docs/coverage_daily.md`
+
+### 禁止事項（共通）
+
+Daily Snapshotの数値が低いからといって、以下を行ってはならない:
+
+1. `# pragma: no cover`を追加してカバレッジを上げる
+2. `.coveragerc`の除外パターンを拡大する
+3. テストをスキップする
+
+これらはCIゲートのポリシー違反として扱われる。

--- a/docs/coverage_daily.md
+++ b/docs/coverage_daily.md
@@ -18,3 +18,8 @@
 
 <!-- newest entries are appended at the end -->
 <!-- DO NOT EDIT MANUALLY -->
+
+### 2026-01-27
+- phase: 1
+- total_coverage: 54%
+- commit: `local`

--- a/scripts/append_coverage_daily_md.py
+++ b/scripts/append_coverage_daily_md.py
@@ -44,5 +44,172 @@ class Snapshot:
     notes: str = ""
 
 
+def parse_total_percent(report_text: str) -> str:
+    """Extract total coverage percentage from report output."""
+    match = TOTAL_RE.search(report_text)
+    if match:
+        return f"{match.group(1)}%"
+
+    match = TOTAL_RE_BRANCH.search(report_text)
+    if match:
+        return f"{match.group(1)}%"
+
+    for line in report_text.splitlines():
+        if line.strip().startswith("TOTAL"):
+            parts = line.split()
+            for part in reversed(parts):
+                if part.endswith("%"):
+                    return part
+
+    raise ValueError(
+        "Could not find TOTAL coverage percent in report output.\n"
+        f"Report content:\n{report_text[:500]}"
+    )
+
+
+def get_previous_coverage(md_path: Path) -> Optional[str]:
+    """Get the most recent coverage value from the MD file."""
+    if not md_path.exists():
+        return None
+
+    content = md_path.read_text(encoding="utf-8")
+    matches = re.findall(r"total_coverage:\s*(\d+%)", content)
+    return matches[-1] if matches else None
+
+
+def calculate_delta(current: str, previous: Optional[str]) -> str:
+    """Calculate coverage delta string."""
+    if not previous:
+        return ""
+
+    try:
+        curr_val = int(current.rstrip("%"))
+        prev_val = int(previous.rstrip("%"))
+        delta = curr_val - prev_val
+        if delta > 0:
+            return f" (+{delta}%)"
+        if delta < 0:
+            return f" ({delta}%)"
+        return " (±0%)"
+    except ValueError:
+        return ""
+
+
+def ensure_header(md_path: Path) -> None:
+    """Ensure the MD file exists with proper header."""
+    if md_path.exists():
+        content = md_path.read_text(encoding="utf-8").strip()
+        if content and "# Daily Coverage Snapshot" in content:
+            return
+
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(
+        "# Daily Coverage Snapshot\n\n"
+        "> **Authority**: REFERENCE (Level 4, Non-binding)  \n"
+        "> **Purpose**: 毎日1回のカバレッジ計測結果を時系列で蓄積する  \n"
+        "> **Timezone**: Asia/Tokyo（JST）\n\n"
+        "---\n\n"
+        "## Log\n\n"
+        "<!-- newest entries are appended at the end -->\n"
+        "<!-- DO NOT EDIT MANUALLY -->\n",
+        encoding="utf-8",
+    )
+
+
+def append_entry(md_path: Path, snap: Snapshot, delta: str) -> None:
+    """Append a new entry to the MD file."""
+    entry_lines = [
+        f"\n### {snap.date_jst}",
+        f"- phase: {snap.phase}",
+        f"- total_coverage: {snap.total_pct}{delta}",
+        f"- commit: `{snap.commit_sha}`",
+    ]
+
+    if snap.run_url:
+        entry_lines.append(f"- workflow_run: {snap.run_url}")
+
+    if snap.notes:
+        entry_lines.append(f"- notes: {snap.notes}")
+
+    entry_lines.append("")
+
+    entry = "\n".join(entry_lines)
+
+    current_content = md_path.read_text(encoding="utf-8")
+    md_path.write_text(current_content + entry, encoding="utf-8")
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Append daily coverage snapshot to MD file"
+    )
+    parser.add_argument(
+        "--md",
+        default="docs/coverage_daily.md",
+        help="Path to coverage_daily.md",
+    )
+    parser.add_argument(
+        "--report",
+        default="artifacts/coverage_daily_term.txt",
+        help="Path to coverage report text file",
+    )
+    parser.add_argument(
+        "--phase",
+        default=os.environ.get("COVERAGE_PHASE", "1"),
+        help="Coverage phase (1 or 2)",
+    )
+    parser.add_argument(
+        "--notes",
+        default="",
+        help="Optional notes to include",
+    )
+    args = parser.parse_args()
+
+    md_path = Path(args.md)
+    report_path = Path(args.report)
+
+    if not report_path.exists():
+        print(f"ERROR: Report file not found: {report_path}", file=sys.stderr)
+        return 1
+
+    ensure_header(md_path)
+
+    try:
+        report_text = report_path.read_text(encoding="utf-8")
+        total_pct = parse_total_percent(report_text)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    jst = ZoneInfo("Asia/Tokyo")
+    date_jst = datetime.now(tz=jst).strftime("%Y-%m-%d")
+
+    commit_sha = os.environ.get("GITHUB_SHA", "")[:12] or "local"
+
+    run_url = ""
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if repo and run_id:
+        run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+
+    previous_coverage = get_previous_coverage(md_path)
+    delta = calculate_delta(total_pct, previous_coverage)
+
+    snap = Snapshot(
+        date_jst=date_jst,
+        phase=str(args.phase),
+        total_pct=total_pct,
+        commit_sha=commit_sha,
+        run_url=run_url,
+        notes=args.notes,
+    )
+
+    append_entry(md_path, snap, delta)
+
+    print(f"Appended coverage snapshot: {date_jst} - {total_pct}{delta}")
+    return 0
+
+
 if __name__ == "__main__":
-    print("Script structure OK")
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide an automated daily coverage snapshot flow that records non-gating coverage measurements to `docs/coverage_daily.md` for trend monitoring.
- Implement a robust parser and append utility to extract the `TOTAL` coverage percent from coverage report output and persist daily entries.
- Add a GitHub Actions workflow to run the snapshot daily and a short policy note that explains the snapshot's role vs. CI gating.

### Description
- Implemented parsing and file-management helpers in `scripts/append_coverage_daily_md.py`: `parse_total_percent`, `get_previous_coverage`, `calculate_delta`, `ensure_header`, `append_entry`, and a `main()` CLI entrypoint that is invoked via `if __name__ == '__main__': sys.exit(main())`.
- Added a scheduled workflow `.github/workflows/coverage-daily.yml` to run the snapshot, append results to `docs/coverage_daily.md`, and upload artifacts; the YAML uses 2-space indentation as requested.
- Appended a "Daily Coverage Snapshotとの役割分担" section to `docs/COVERAGE_POLICY.md` and added an initial snapshot entry to `docs/coverage_daily.md` (new entry shows date/phase/coverage/commit).

### Testing
- Ran `python scripts/append_coverage_daily_md.py --help` which printed the CLI help successfully. (success)
- Executed `bash scripts/daily_coverage_snapshot.sh && python scripts/append_coverage_daily_md.py` but the full run failed because `coverage`/`pytest-cov` are not available in the environment and install attempts were blocked by proxy, so pytest returned a non-zero exit and coverage reporting via `python -m coverage` was unavailable. (expected failure in this environment)
- Verified end-to-end append flow by copying an existing `coverage_report.txt` into `artifacts/coverage_daily_term.txt` and running `python scripts/append_coverage_daily_md.py`, which appended a `### YYYY-MM-DD` entry to `docs/coverage_daily.md` and printed an "Appended coverage snapshot" message. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978990c73748330a74f41e4ff9bbd1c)