### PR TITLE
fix(docker): add web runtime deps and writable data dir for container…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN pip install uv
 # Copy dependency files
 COPY pyproject.toml uv.lock* ./
 
-# Install dependencies
-RUN uv sync --no-dev --frozen || uv sync --no-dev
+# Install runtime dependencies + web extras (fastapi/uvicorn)
+RUN uv sync --no-dev --extra web --frozen || uv sync --no-dev --extra web
 
 # ===== Runtime Stage =====
 FROM python:3.11-slim as runtime
@@ -34,6 +34,9 @@ COPY --from=builder /app/.venv /app/.venv
 COPY jarvis_core/ ./jarvis_core/
 COPY jarvis_web/ ./jarvis_web/
 COPY jarvis_cli.py ./
+
+# Prepare writable runtime directories for non-root process
+RUN mkdir -p /app/data/locks && chown -R jarvis:jarvis /app/data
 
 # Set environment variables
 ENV PATH="/app/.venv/bin:$PATH"

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,106 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260212101225+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260212101225+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 3 /Kids [ 3 0 R 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 105
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CT3",gCK)'Qp-TgkCg!Khq"8?RP65[o&>Jt]&.8<uSu(.ahp(BASF(#o~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 105
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CT3",gCK)'Qp-TgkCg!Khq"8?RP65[o&>Jruos8<uSu(.ahp(BAST($#~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 105
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CT3",gCK)'Qp-TgkCg!Khq"8?RP65[o&>K!D1>8<uSu(.ahp(BASb($,~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000586 00000 n 
+0000000780 00000 n 
+0000000848 00000 n 
+0000001109 00000 n 
+0000001180 00000 n 
+0000001375 00000 n 
+0000001571 00000 n 
+trailer
+<<
+/ID 
+[<bc1101f477775da5d91ec6ec3dd6ebb0><bc1101f477775da5d91ec6ec3dd6ebb0>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 12
+>>
+startxref
+1767
+%%EOF


### PR DESCRIPTION
## What
- Docker runtime imageにweb依存を追加（`uv sync --no-dev --extra web`）
- 非root実行時に必要な`/app/data/locks`を事前作成して権限付与

## Why
- `docker run ... jarvis-test` で `No module named uvicorn` が発生していた
- 起動時に `PermissionError: data/locks` で落ちていた

## Validation
- `docker build -t jarvis-test .` 成功
- `docker run --rm -p 8000:8000 jarvis-test` で起動成功
- `GET /api/health` が `200 OK` を返すことを確認
- コンテナ内テスト: `6368 passed, 462 skipped, 0 failed`
