### PR TITLE
feat(ops_extract): enforce strict contracts and committed-proof sync (P1-P6)

### DIFF
--- a/jarvis_core/ops_extract/cli/javisctl.py
+++ b/jarvis_core/ops_extract/cli/javisctl.py
@@ -104,6 +104,12 @@ def _cmd_cancel(args: argparse.Namespace) -> int:
 def _cmd_sync(args: argparse.Namespace) -> int:
     queue_dir = Path(args.queue_dir)
     items = load_sync_queue(queue_dir)
+    if args.only_human_action:
+        items = [
+            item
+            for item in items
+            if str(item.get("state", "")) in {"failed", "human_action_required"}
+        ]
     for item in items:
         path = Path(str(item.get("_path", "")))
         run_dir = Path(str(item.get("run_dir", "")))
@@ -228,6 +234,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument("--upload-base-url")
     p_sync.add_argument("--dry-run", action="store_true")
     p_sync.add_argument("--no-verify", action="store_true")
+    p_sync.add_argument("--only-human-action", action="store_true")
     p_sync.set_defaults(func=_cmd_sync)
 
     p_audit = sub.add_parser("audit")

--- a/jarvis_core/ops_extract/doctor.py
+++ b/jarvis_core/ops_extract/doctor.py
@@ -27,12 +27,27 @@ def run_doctor(
         if str(item.get("state", "")) in {"failed", "human_action_required"}
     ]
     score = generate_weekly_report()
+    drive_api_reachable = bool(diagnosis.get("drive_api_reachable"))
+    next_commands: list[str] = []
+    next_notes: list[str] = []
+    if len(failed_items) > 0:
+        next_commands.append("javisctl sync --only-human-action")
+    elif len(queue_items) > 0:
+        next_commands.append("javisctl sync")
+    elif not drive_api_reachable:
+        next_commands.append("javisctl doctor")
+        next_notes.append("network_hint: ネットワーク復旧後に再実行してください。")
+    elif score.ops_score < 70 or score.extract_score < 70:
+        next_commands.append("javisctl weekly-report")
+    else:
+        next_commands.append("javisctl weekly-report")
+
     report_path = reports_dir / f"{now.strftime('%Y%m%dT%H%M%SZ')}.md"
     with open(report_path, "w", encoding="utf-8") as f:
         f.write("# Ops+Extract Doctor Report\n\n")
         f.write(f"- timestamp: {now.isoformat()}\n")
         f.write(f"- network_profile: {profile}\n")
-        f.write(f"- drive_api_reachable: {diagnosis.get('drive_api_reachable')}\n")
+        f.write(f"- drive_api_reachable: {drive_api_reachable}\n")
         f.write(f"- queue_total: {len(queue_items)}\n")
         f.write(f"- queue_human_action_required: {len(failed_items)}\n")
         f.write(f"- ops_score: {score.ops_score}\n")
@@ -44,4 +59,9 @@ def run_doctor(
                     f"- run_id={item.get('run_id','')} state={item.get('state','')} "
                     f"error={item.get('last_error','')}\n"
                 )
+        f.write("\n## Next Commands\n")
+        for command in next_commands:
+            f.write(f"- `{command}`\n")
+        for note in next_notes:
+            f.write(f"- {note}\n")
     return report_path

--- a/jarvis_core/ops_extract/drive_client.py
+++ b/jarvis_core/ops_extract/drive_client.py
@@ -278,7 +278,14 @@ class DriveResumableClient:
                 fields="files(id,name,mimeType,createdTime)",
             )
             if len(existing) > 1:
-                raise DriveUploadError(f"duplicate_folder_detected:{name}")
+                duplicate_ids = [
+                    str(item.get("id", "")).strip()
+                    for item in existing
+                    if str(item.get("id", "")).strip()
+                ]
+                raise DriveUploadError(
+                    f"duplicate_folder_detected:{name}:ids={','.join(duplicate_ids)}"
+                )
             if len(existing) == 1:
                 return str(existing[0].get("id", ""))
             payload: dict[str, Any] = {

--- a/jarvis_core/ops_extract/schema_validate.py
+++ b/jarvis_core/ops_extract/schema_validate.py
@@ -113,3 +113,92 @@ def validate_run_contracts(run_dir: Path) -> list[str]:
         except Exception as exc:
             errors.append(str(exc))
     return errors
+
+
+def list_expected_contract_files(*, include_ocr_meta: bool) -> list[str]:
+    expected = []
+    for filename in SCHEMA_BY_FILENAME:
+        if filename == "crash_dump.json":
+            continue
+        if not include_ocr_meta and filename == "ocr/ocr_meta.json":
+            continue
+        expected.append(filename)
+    return expected
+
+
+def _read_run_status(run_dir: Path) -> str:
+    run_metadata_path = run_dir / "run_metadata.json"
+    manifest_path = run_dir / "manifest.json"
+    for path in (run_metadata_path, manifest_path):
+        if not path.exists():
+            continue
+        try:
+            payload = _load_json(path)
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            status = str(payload.get("status", "")).strip().lower()
+            if status:
+                return status
+    return ""
+
+
+def _count_non_empty_jsonl_lines(path: Path) -> int:
+    count = 0
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def validate_run_contracts_strict(run_dir: Path, *, include_ocr_meta: bool) -> list[str]:
+    errors: list[str] = []
+
+    expected = list_expected_contract_files(include_ocr_meta=include_ocr_meta)
+    status = _read_run_status(run_dir)
+    if status == "failed":
+        expected.append("crash_dump.json")
+
+    for filename in expected:
+        path = run_dir / filename
+        if not path.exists():
+            errors.append(f"missing:{filename}")
+
+    for filename in expected:
+        path = run_dir / filename
+        if not path.exists():
+            continue
+        try:
+            validate_contract_path(path, contract_name=filename)
+        except Exception as exc:
+            errors.append(str(exc))
+
+    trace_path = run_dir / "trace.jsonl"
+    if trace_path.exists():
+        try:
+            if _count_non_empty_jsonl_lines(trace_path) == 0:
+                errors.append("empty_jsonl:trace.jsonl")
+        except Exception as exc:
+            errors.append(f"jsonl_check_failed:trace.jsonl:{exc}")
+
+    warnings_jsonl_path = run_dir / "warnings.jsonl"
+    if warnings_jsonl_path.exists():
+        try:
+            if _count_non_empty_jsonl_lines(warnings_jsonl_path) == 0:
+                errors.append("empty_jsonl:warnings.jsonl")
+        except Exception as exc:
+            errors.append(f"jsonl_check_failed:warnings.jsonl:{exc}")
+
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest_payload = _load_json(manifest_path)
+            if isinstance(manifest_payload, dict):
+                outputs = manifest_payload.get("outputs")
+                if isinstance(outputs, list) and len(outputs) == 0:
+                    errors.append("empty_outputs:manifest.json")
+        except Exception as exc:
+            errors.append(f"manifest_parse_failed:{exc}")
+
+    return errors

--- a/tests/e2e/test_contract_gate_hard_fail.py
+++ b/tests/e2e/test_contract_gate_hard_fail.py
@@ -35,7 +35,7 @@ def test_contract_validation_forces_failed_status(tmp_path: Path):
             return_value=_good_extraction(),
         ),
         patch(
-            "jarvis_core.ops_extract.orchestrator.validate_run_contracts",
+            "jarvis_core.ops_extract.orchestrator.validate_run_contracts_strict",
             return_value=["manifest.schema.json:required status"],
         ),
     ):

--- a/tests/e2e/test_ops_extract_worst_cases_smoke.py
+++ b/tests/e2e/test_ops_extract_worst_cases_smoke.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from jarvis_core.ops_extract.contracts import OpsExtractConfig
+from jarvis_core.ops_extract.doctor import run_doctor
+from jarvis_core.ops_extract.drive_sync import sync_run_to_drive
+from jarvis_core.ops_extract.schema_validate import validate_run_contracts_strict
+
+
+def test_worst_case_contract_missing_smoke(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "status": "success",
+                "outputs": [{"path": "result.json", "size": 1, "sha256": "a" * 64}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    errors = validate_run_contracts_strict(run_dir, include_ocr_meta=False)
+    assert any(error.startswith("missing:") for error in errors)
+
+
+def test_worst_case_drive_sync_targets_manifest_outputs_smoke(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = run_dir / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "x.json").write_text("{}", encoding="utf-8")
+    (out_dir / "y.json").write_text("{}", encoding="utf-8")
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "run_id": "r1",
+                "project": "demo",
+                "created_at": "2026-02-14T00:00:00+00:00",
+                "finished_at": "2026-02-14T00:00:00+00:00",
+                "status": "success",
+                "inputs": [],
+                "outputs": [
+                    {"path": "out/x.json", "size": 2, "sha256": "x" * 64},
+                    {"path": "out/y.json", "size": 2, "sha256": "y" * 64},
+                ],
+                "extract": {
+                    "method": "pdf_text",
+                    "needs_ocr": False,
+                    "needs_ocr_reason": "",
+                    "total_chars": 2,
+                    "chars_per_page_mean": 2.0,
+                    "empty_page_ratio": 0.0,
+                },
+                "ops": {"retries": 0, "resume_count": 0, "sync_state": "not_started"},
+                "committed": False,
+                "committed_local": True,
+                "committed_drive": False,
+                "version": "ops_extract_manifest_v2",
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = sync_run_to_drive(
+        run_dir=run_dir,
+        enabled=True,
+        dry_run=True,
+        upload_workers=2,
+    )
+    uploaded_paths = {str(item.get("path", "")).strip() for item in state["uploaded_files"]}
+    assert {"out/x.json", "out/y.json", "manifest.json"}.issubset(uploaded_paths)
+
+
+def test_worst_case_doctor_has_next_commands_smoke(tmp_path: Path):
+    queue_dir = tmp_path / "sync_queue"
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    (queue_dir / "r1.json").write_text(
+        json.dumps({"run_id": "r1", "state": "failed", "created_at": "2026-01-01T00:00:00+00:00"}),
+        encoding="utf-8",
+    )
+    with patch(
+        "jarvis_core.ops_extract.doctor.detect_network_profile",
+        return_value=("OFFLINE", {"drive_api_reachable": False}),
+    ):
+        report = run_doctor(
+            config=OpsExtractConfig(enabled=True, sync_queue_dir=str(queue_dir)),
+            queue_dir=queue_dir,
+            reports_dir=tmp_path / "doctor_reports",
+        )
+    content = report.read_text(encoding="utf-8")
+    assert "## Next Commands" in content

--- a/tests/ops_extract/test_contract_strict_missing_is_error.py
+++ b/tests/ops_extract/test_contract_strict_missing_is_error.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.schema_validate import validate_run_contracts_strict
+
+
+def test_contract_strict_missing_is_error(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "status": "success",
+                "outputs": [{"path": "ingestion/text.md", "size": 1, "sha256": "a" * 64}],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = validate_run_contracts_strict(run_dir, include_ocr_meta=False)
+    assert any(err.startswith("missing:") for err in errors)
+    assert any(err == "missing:run_metadata.json" for err in errors)

--- a/tests/ops_extract/test_contract_strict_rejects_empty_trace.py
+++ b/tests/ops_extract/test_contract_strict_rejects_empty_trace.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.schema_validate import validate_run_contracts_strict
+
+
+def test_contract_strict_rejects_empty_trace(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "trace.jsonl").write_text("", encoding="utf-8")
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "status": "success",
+                "outputs": [{"path": "result.json", "size": 1, "sha256": "b" * 64}],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = validate_run_contracts_strict(run_dir, include_ocr_meta=False)
+    assert "empty_jsonl:trace.jsonl" in errors

--- a/tests/ops_extract/test_doctor_includes_next_commands.py
+++ b/tests/ops_extract/test_doctor_includes_next_commands.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from jarvis_core.ops_extract.contracts import OpsExtractConfig
+from jarvis_core.ops_extract.doctor import run_doctor
+
+
+def test_doctor_includes_next_commands(tmp_path: Path):
+    queue_dir = tmp_path / "sync_queue"
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    (queue_dir / "r1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "run_id": "r1",
+                "state": "human_action_required",
+                "created_at": "2026-02-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch(
+        "jarvis_core.ops_extract.doctor.detect_network_profile",
+        return_value=("ONLINE", {"drive_api_reachable": True}),
+    ):
+        report = run_doctor(
+            config=OpsExtractConfig(enabled=True, sync_queue_dir=str(queue_dir)),
+            queue_dir=queue_dir,
+            reports_dir=tmp_path / "doctor_reports",
+        )
+    content = report.read_text(encoding="utf-8")
+    assert "## Next Commands" in content
+    assert "javisctl sync --only-human-action" in content

--- a/tests/ops_extract/test_drive_client_duplicate_folder_error_includes_ids.py
+++ b/tests/ops_extract/test_drive_client_duplicate_folder_error_includes_ids.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvis_core.ops_extract.drive_client import DriveResumableClient, DriveUploadError
+
+
+def test_drive_client_duplicate_folder_error_includes_ids(monkeypatch):
+    client = DriveResumableClient(
+        access_token="token",
+        api_base_url="https://www.googleapis.com/drive/v3",
+        upload_base_url="https://www.googleapis.com/upload/drive/v3/files",
+    )
+    monkeypatch.setattr(
+        client,
+        "list_children",
+        lambda **_kwargs: [{"id": "folder-1"}, {"id": "folder-2"}],
+    )
+
+    with pytest.raises(DriveUploadError) as exc_info:
+        client.ensure_folder(name="dup", parent_id="root")
+
+    message = str(exc_info.value)
+    assert "duplicate_folder_detected:dup" in message
+    assert "ids=folder-1,folder-2" in message

--- a/tests/ops_extract/test_drive_sync_targets_manifest_outputs.py
+++ b/tests/ops_extract/test_drive_sync_targets_manifest_outputs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.drive_sync import sync_run_to_drive
+
+
+def test_drive_sync_targets_manifest_outputs(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    first = run_dir / "artifacts" / "a.json"
+    second = run_dir / "artifacts" / "b.json"
+    first.write_text("{}", encoding="utf-8")
+    second.write_text("{}", encoding="utf-8")
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "run_id": "r1",
+                "project": "demo",
+                "created_at": "2026-02-14T00:00:00+00:00",
+                "finished_at": "2026-02-14T00:00:01+00:00",
+                "status": "success",
+                "inputs": [],
+                "outputs": [
+                    {"path": "artifacts/a.json", "size": 2, "sha256": "a" * 64},
+                    {"path": "artifacts/b.json", "size": 2, "sha256": "b" * 64},
+                ],
+                "extract": {
+                    "method": "pdf_text",
+                    "needs_ocr": False,
+                    "needs_ocr_reason": "",
+                    "total_chars": 2,
+                    "chars_per_page_mean": 2.0,
+                    "empty_page_ratio": 0.0,
+                },
+                "ops": {"retries": 0, "resume_count": 0, "sync_state": "not_started"},
+                "committed": False,
+                "committed_local": True,
+                "committed_drive": False,
+                "version": "ops_extract_manifest_v2",
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    state = sync_run_to_drive(
+        run_dir=run_dir,
+        enabled=True,
+        dry_run=True,
+        upload_workers=2,
+    )
+    uploaded_paths = {str(item.get("path", "")).strip() for item in state["uploaded_files"]}
+    assert "artifacts/a.json" in uploaded_paths
+    assert "artifacts/b.json" in uploaded_paths
+    assert "manifest.json" in uploaded_paths

--- a/tests/ops_extract/test_preflight_fails_on_queue_backlog_in_strict.py
+++ b/tests/ops_extract/test_preflight_fails_on_queue_backlog_in_strict.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.contracts import OpsExtractConfig
+from jarvis_core.ops_extract.preflight import run_preflight_checks
+
+
+def test_preflight_fails_on_queue_backlog_in_strict(tmp_path: Path):
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4")
+    queue_dir = tmp_path / "sync_queue"
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    for idx in range(3):
+        (queue_dir / f"item-{idx}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "ops_extract_contract_v2",
+                    "run_id": f"r{idx}",
+                    "state": "pending",
+                    "created_at": "2025-01-01T00:00:00+00:00",
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    report = run_preflight_checks(
+        input_paths=[input_pdf],
+        config=OpsExtractConfig(
+            enabled=True,
+            sync_enabled=True,
+            sync_queue_dir=str(queue_dir),
+            preflight_rule_mode="strict",
+            lessons_path=str(tmp_path / "lessons.md"),
+        ),
+    )
+
+    assert report.passed is False
+    assert any("check_sync_queue_backlog" in error for error in report.errors)


### PR DESCRIPTION
﻿## Goal
ops_extract の Proof-Driven Hardening v1.0（P1-P6）を追加実装し、欠損・空・不整合が success/committed に到達しないことをコードとテストで保証する。

## Scope
- P1: strict contract validation（missing/empty を error 化）
- P2: Drive sync の対象を manifest.outputs 基準へ統一
- P3: doctor の `## Next Commands` 必須化 + `sync --only-human-action`
- P4: sync queue backlog を preflight で検知
- P5: duplicate folder エラーに IDs を含める
- P6: worst-case smoke E2E 追加

## Changes
- `jarvis_core/ops_extract/schema_validate.py`
  - `list_expected_contract_files`
  - `validate_run_contracts_strict`
- `jarvis_core/ops_extract/orchestrator.py`
  - strict validator を強制適用
  - contract error 時の failed/committed フラグ上書き
- `jarvis_core/ops_extract/drive_sync.py`
  - manifest.outputs 由来の同期対象
  - committed 直前の uploaded files 完全性検証
- `jarvis_core/ops_extract/doctor.py`
  - `## Next Commands` 出力追加
- `jarvis_core/ops_extract/cli/javisctl.py`
  - `sync --only-human-action` 追加
- `jarvis_core/ops_extract/sync_queue.py`
  - `queue_summary` 追加
- `jarvis_core/ops_extract/preflight.py`
  - `check_sync_queue_backlog` 追加（sync_enabled=True 時のみ）
- `jarvis_core/ops_extract/drive_client.py`
  - duplicate folder エラーに `ids=` 追加

## Tests
- New:
  - `tests/ops_extract/test_contract_strict_missing_is_error.py`
  - `tests/ops_extract/test_contract_strict_rejects_empty_trace.py`
  - `tests/ops_extract/test_drive_sync_targets_manifest_outputs.py`
  - `tests/ops_extract/test_doctor_includes_next_commands.py`
  - `tests/ops_extract/test_preflight_fails_on_queue_backlog_in_strict.py`
  - `tests/ops_extract/test_drive_client_duplicate_folder_error_includes_ids.py`
  - `tests/e2e/test_ops_extract_worst_cases_smoke.py`
- Updated:
  - `tests/e2e/test_contract_gate_hard_fail.py`

## Validation
- `uv run pytest tests/ops_extract tests/e2e/test_ops_extract_proof_driven.py -q` -> 76 passed, 1 skipped
- `uv run pytest tests/e2e/test_contract_gate_hard_fail.py tests/e2e/test_ops_extract_worst_cases_smoke.py -q` -> 4 passed
- `uv run python scripts/no_stub_gate.py --paths jarvis_core/ops_extract` -> PASS
- `uv run ruff check jarvis_core tests` -> PASS
- `uv run black --check jarvis_core tests` -> PASS
- `uv run python scripts/security_gate.py` -> PASS
- `uv run python -m build` -> SUCCESS
