### PR TITLE
chore(tooling): remove deprecated ruff/license settings and BOM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "JARVIS Research OS - AI-Powered Systematic Literature Review Assistant"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "JARVIS Team", email = "jarvis@kaneko-ai.dev"}
 ]
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 
@@ -132,16 +131,18 @@ target-version = ["py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "W"]
 ignore = [
     "E501",   # Line too long - 段階的に対応
     "E741",   # Ambiguous variable name - レガシーコード対応
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["jarvis_core", "jarvis_web", "jarvis_tools"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "scripts/jarvis_doctor.py" = ["F401"]
 "jarvis_core/trend/sources/__init__.py" = ["F401"]
 "jarvis_core/lab/__init__.py" = ["F401"]

--- a/scripts/detect_garbage_code.py
+++ b/scripts/detect_garbage_code.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 """Detect placeholder or garbage code patterns."""
 
 from __future__ import annotations

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 """Quality gate utilities.
 
 This script supports two modes:

--- a/scripts/validate_bundle.py
+++ b/scripts/validate_bundle.py
@@ -1,4 +1,4 @@
-﻿"""TD-003: Bundle contract validator.
+"""TD-003: Bundle contract validator.
 
 Validates that a run bundle contains all required files and valid JSON/JSONL content.
 """


### PR DESCRIPTION
## Goal
ツール/ビルド系の非推奨警告を削減し、security gateのBOM警告を解消する。

## Non-Goal
機能仕様の変更は行わない。

## Changes
- pyproject.toml の license を SPDX文字列へ変更
- deprecatedな license classifier を削除
- Ruff設定を 	ool.ruff.lint 配下へ移行
- 3つのスクリプトから UTF-8 BOM を除去

## Tests
- uv run ruff check jarvis_core tests
- uv run python scripts/security_gate.py
- uv run python -m build

## Rollback
- pyproject.toml と対象3スクリプトを元に戻す。