### PR TITLE
refactor(core): remove datetime/pydantic deprecations

### DIFF
--- a/jarvis_core/browser/recording.py
+++ b/jarvis_core/browser/recording.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -51,5 +51,5 @@ class BrowserRecorder:
 
 
 def generate_session_id(prefix: str = "browser") -> str:
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y%m%d%H%M%S")
     return f"{prefix}_{timestamp}"

--- a/jarvis_core/collaboration/comments.py
+++ b/jarvis_core/collaboration/comments.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 import uuid
 
@@ -50,7 +50,7 @@ class CommentStore:
             content=content,
             selection=selection,
             mentions=mentions,
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
         )
         self._comments[comment_id] = comment
         self._by_artifact.setdefault(artifact_id, []).append(comment_id)

--- a/jarvis_core/collaboration/versioning.py
+++ b/jarvis_core/collaboration/versioning.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import difflib
 import uuid
 
@@ -33,7 +33,7 @@ class VersionHistoryStore:
             artifact_id=artifact_id,
             content_hash=content_hash,
             author=author,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             content=content,
         )
         self._versions.setdefault(artifact_id, []).append(version)

--- a/jarvis_core/contracts/types.py
+++ b/jarvis_core/contracts/types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -87,7 +87,9 @@ class TaskContext:
     domain: str = "general"
     constraints: list[str] = field(default_factory=list)
     seed: int = 42
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+    )
     run_id: str = field(default_factory=lambda: str(uuid.uuid4())[:12])
     user_id: str | None = None
     priority: int = 5
@@ -331,7 +333,9 @@ class ResultBundle:
         return rate >= min_rate
 
     def add_log(self, message: str) -> None:
-        self.logs.append(f"[{datetime.utcnow().isoformat()}] {message}")
+        self.logs.append(
+            f"[{datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}] {message}"
+        )
 
     def mark_error(self, error: str) -> None:
         self.success = False

--- a/jarvis_core/decision/elicitation.py
+++ b/jarvis_core/decision/elicitation.py
@@ -80,7 +80,7 @@ def template_payload() -> dict[str, object]:
 def validate_payload(payload: dict[str, object]) -> dict[str, object]:
     """Validate payload and return either parsed data or errors."""
     try:
-        parsed = DecisionInput.parse_obj(payload)
+        parsed = DecisionInput.model_validate(payload)
         return {
             "valid": True,
             "errors": [],

--- a/jarvis_core/decision/report.py
+++ b/jarvis_core/decision/report.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .schema import DISCLAIMER_TEXT, DecisionComparison
@@ -12,7 +12,7 @@ def build_markdown_report(comparison: DecisionComparison) -> str:
     """Build a markdown report from decision comparison."""
     lines = [
         "# Decision Intelligence Report",
-        f"- Generated: {datetime.utcnow().isoformat()}Z",
+        f"- Generated: {datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}Z",
         f"- Disclaimer: {DISCLAIMER_TEXT}",
         "",
     ]

--- a/jarvis_core/decision/schema.py
+++ b/jarvis_core/decision/schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 DISCLAIMER_TEXT = "仮定に依存する（推測です）"
 
@@ -15,7 +15,8 @@ class RationaleValue(BaseModel):
     value: float
     rationale: str = Field(..., min_length=1)
 
-    @validator("rationale")
+    @field_validator("rationale")
+    @classmethod
     def _rationale_not_empty(cls, value: str) -> str:
         if not value.strip():
             raise ValueError("rationale is required for numeric values")

--- a/jarvis_core/eval/ab_testing.py
+++ b/jarvis_core/eval/ab_testing.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -85,7 +85,7 @@ class ABTestingFramework:
             name=name,
             variants=variants,
             traffic_split=traffic_split,
-            start_date=datetime.utcnow().isoformat() + "Z",
+            start_date=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             end_date=None,
             status="draft",
             metrics=metrics or ["success_rate"],
@@ -149,7 +149,8 @@ class ABTestingFramework:
             f.write(
                 json.dumps(
                     {
-                        "timestamp": datetime.utcnow().isoformat() + "Z",
+                        "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+                        + "Z",
                         "variant": variant,
                         "metric": metric,
                         "value": value,
@@ -249,5 +250,7 @@ class ABTestingFramework:
         """Stop an experiment."""
         if experiment_id in self._experiments:
             self._experiments[experiment_id].status = "completed"
-            self._experiments[experiment_id].end_date = datetime.utcnow().isoformat() + "Z"
+            self._experiments[experiment_id].end_date = (
+                datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z"
+            )
             self._save_experiment(self._experiments[experiment_id])

--- a/jarvis_core/eval/auto_eval.py
+++ b/jarvis_core/eval/auto_eval.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -112,7 +112,7 @@ class AutomatedEvalPipeline:
 
         run = EvalRun(
             run_id=f"eval_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             metrics=metrics,
             cases_passed=passed,
             cases_failed=failed,

--- a/jarvis_core/metadata/normalize.py
+++ b/jarvis_core/metadata/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -27,7 +27,7 @@ def normalize_record(paper: dict[str, Any]) -> dict[str, Any]:
 
 
 def audit_records(papers: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    current_year = datetime.utcnow().year
+    current_year = datetime.now(timezone.utc).replace(tzinfo=None).year
     normalized = [normalize_record(p) for p in papers]
 
     doi_titles: dict[str, set] = {}

--- a/jarvis_core/observability/stack.py
+++ b/jarvis_core/observability/stack.py
@@ -9,7 +9,7 @@ import json
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -310,7 +310,7 @@ class Logger:
     ) -> None:
         """Internal log method."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             "level": level,
             "logger": self.name,
             "message": message,

--- a/jarvis_core/ops/audit.py
+++ b/jarvis_core/ops/audit.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +45,7 @@ class AuditLogger:
         self.log_dir = log_dir or Path("artifacts/audit")
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.entries: list[AuditEntry] = []
-        self.run_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        self.run_id = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y%m%d_%H%M%S")
 
     def log(
         self,
@@ -58,7 +58,7 @@ class AuditLogger:
     ) -> AuditEntry:
         """監査ログを記録."""
         entry = AuditEntry(
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             run_id=self.run_id,
             stage=stage,
             action=action,

--- a/jarvis_core/optimization/report.py
+++ b/jarvis_core/optimization/report.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from jarvis_core.finance.scenarios import ScenarioResult
 from jarvis_core.optimization.solver import ScenarioEvaluation
@@ -25,7 +25,7 @@ def generate_markdown(
 ) -> str:
     lines = [
         "# P10 Resource Optimization Report",
-        f"> Generated at {datetime.utcnow().isoformat()}Z",
+        f"> Generated at {datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}Z",
         "",
         f"> すべての結果は仮定依存です {ASSUMPTION_NOTE}",
         "",
@@ -55,7 +55,7 @@ def generate_html(
 ) -> str:
     sections = [
         "<h1>P10 Resource Optimization Report</h1>",
-        f"<p>Generated at {datetime.utcnow().isoformat()}Z</p>",
+        f"<p>Generated at {datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}Z</p>",
         f"<p>すべての結果は仮定依存です {ASSUMPTION_NOTE}</p>",
     ]
     for scenario_id, result in scenarios.items():

--- a/jarvis_core/reliability/health.py
+++ b/jarvis_core/reliability/health.py
@@ -93,12 +93,12 @@ class HealthChecker:
         Returns:
             HealthReport for liveness.
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         return HealthReport(
             status=HealthStatus.HEALTHY,
             checks=[],
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             version=self.version,
             uptime_seconds=time.time() - self.start_time,
         )
@@ -109,7 +109,7 @@ class HealthChecker:
         Returns:
             HealthReport with all checks.
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         results = []
         overall_status = HealthStatus.HEALTHY
@@ -143,7 +143,7 @@ class HealthChecker:
         return HealthReport(
             status=overall_status,
             checks=results,
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             version=self.version,
             uptime_seconds=time.time() - self.start_time,
         )
@@ -154,7 +154,7 @@ class HealthChecker:
         Returns:
             HealthReport with all checks.
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         results = []
         overall_status = HealthStatus.HEALTHY
@@ -202,7 +202,7 @@ class HealthChecker:
         return HealthReport(
             status=overall_status,
             checks=results,
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             version=self.version,
             uptime_seconds=time.time() - self.start_time,
         )

--- a/jarvis_core/review/living_updater.py
+++ b/jarvis_core/review/living_updater.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 
 from jarvis_core.advanced.features import SystematicReviewAgent
 from jarvis_core.evidence.ensemble import grade_evidence
@@ -41,7 +41,7 @@ class LivingReviewUpdater:
         but for this implementation we simulate by filtering provided papers.
         """
         last_check_str = self._last_checked.get(review_id)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         self._last_checked[review_id] = now.isoformat()
 
         if not last_check_str:
@@ -74,7 +74,7 @@ class LivingReviewUpdater:
         prisma_flow = review.get_prisma_flow()
         return UpdateReport(
             review_id=review_id,
-            updated_at=datetime.utcnow().isoformat(),
+            updated_at=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             new_papers=new_papers,
             evidence_grades=evidence_grades,
             prisma_flow=prisma_flow,

--- a/jarvis_core/runtime/durable.py
+++ b/jarvis_core/runtime/durable.py
@@ -63,13 +63,13 @@ class DurableRunner:
             completed: Completed item IDs.
             pending: Pending item IDs.
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         checkpoint = Checkpoint(
             run_id=self.run_id,
             stage=stage,
             step_id=self._step_id,
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             data=data,
             completed_items=completed or [],
             pending_items=pending or [],

--- a/jarvis_core/scheduler/schema.py
+++ b/jarvis_core/scheduler/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class ScheduleQuery(BaseModel):
@@ -18,7 +18,8 @@ class ScheduleQuery(BaseModel):
     sort: str = "pub_date_desc"
     force_refresh: bool = False
 
-    @validator("oa_policy")
+    @field_validator("oa_policy")
+    @classmethod
     def validate_oa_policy(cls, value: str) -> str:
         if value not in {"strict", "lenient"}:
             raise ValueError("oa_policy must be strict or lenient")
@@ -108,7 +109,7 @@ def normalize_schedule_payload(
         updated_at=data.get("updated_at", _now()),
         degraded=bool(data.get("degraded", False)),
     )
-    return model.dict()
+    return model.model_dump()
 
 
 def validate_required_fields(payload: dict[str, Any]) -> None:

--- a/jarvis_core/scoring/paper_score.py
+++ b/jarvis_core/scoring/paper_score.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -63,7 +63,7 @@ def _score_reliability(paper: dict[str, Any]) -> float:
     if paper.get("journal"):
         score += 10.0
     year = int(paper.get("year") or 0)
-    current_year = datetime.utcnow().year
+    current_year = datetime.now(timezone.utc).replace(tzinfo=None).year
     if year > 0:
         score += 5.0
         if current_year - year <= 5:

--- a/jarvis_core/security/audit.py
+++ b/jarvis_core/security/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -61,7 +61,7 @@ class AuditLogger:
         return entries
 
     def _log_entry(self, action: str, user: str, details: dict) -> AuditEntry:
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
         date_key = timestamp.split("T")[0]
         prev_hash = self._last_hash.get(date_key)
         payload = json.dumps(

--- a/jarvis_core/supervisor/lyra.py
+++ b/jarvis_core/supervisor/lyra.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -162,7 +162,7 @@ DECONSTRUCT → DIAGNOSE → DEVELOP → DELIVER → repeat."""
 
     def _generate_run_id(self) -> str:
         """Generate unique run ID."""
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
         return hashlib.sha256(now.encode()).hexdigest()[:12]
 
     def _log(
@@ -175,7 +175,7 @@ DECONSTRUCT → DIAGNOSE → DEVELOP → DELIVER → repeat."""
     ) -> None:
         """Add entry to audit log."""
         log = SupervisionLog(
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             run_id=self.run_id,
             phase=phase,
             issue_detected=issue,
@@ -612,7 +612,7 @@ Outputs without evidence_links will be REJECTED.
         Returns:
             DeliverResult ready for execution
         """
-        task_id = f"task-{self.run_id}-{datetime.utcnow().strftime('%H%M%S')}"
+        task_id = f"task-{self.run_id}-{datetime.now(timezone.utc).replace(tzinfo=None).strftime('%H%M%S')}"
 
         result = DeliverResult(
             task_id=task_id,

--- a/scripts/generate_release_bundle.py
+++ b/scripts/generate_release_bundle.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import shutil
 import json
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def generate_release_bundle(
@@ -81,7 +81,7 @@ python scripts/bench.py --cases docs/evals/bench_cases.jsonl
     # Generate manifest
     manifest = {
         "version": version,
-        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "generated_at": datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
         "files": [f.name for f in out_path.iterdir()],
     }
 

--- a/scripts/kpi_report.py
+++ b/scripts/kpi_report.py
@@ -10,7 +10,7 @@ import csv
 from dataclasses import dataclass
 from typing import List, Optional
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 @dataclass
@@ -41,7 +41,7 @@ def compute_kpis(
         KPISnapshot with computed metrics.
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z"
 
     total = len(runs)
     if total == 0:

--- a/scripts/run_regression.py
+++ b/scripts/run_regression.py
@@ -9,7 +9,7 @@ import json
 import sys
 import argparse
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 
@@ -73,7 +73,7 @@ def compute_summary(results: List[Dict[str, Any]]) -> Dict[str, Any]:
         "success_rate": success / total,
         "avg_claim_precision": avg("claim_precision"),
         "avg_citation_precision": avg("citation_precision"),
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
     }
 
 


### PR DESCRIPTION
## Goal
ランタイム本体側の主要deprecation警告（datetime.utcnow / Pydantic v1 API）を解消する。

## Non-Goal
機能仕様や入出力契約は変更しない。

## Changes
- datetime.utcnow() を timezone-aware ベース実装へ置換（互換のため naive UTCフォーマットを維持）
- @validator を @field_validator へ移行
- parse_obj を model_validate へ置換
- model.dict() を model_dump() へ置換

## Tests
- uv run pytest tests/test_decision_modules.py tests/test_scheduler_engine.py tests/test_td002_scheduler_lyra_health_cov.py tests/test_cov85_security_audit.py tests/test_reliability_security.py -q -W error::DeprecationWarning
- uv run ruff check jarvis_core tests
- uv run black --check jarvis_core tests

## Rollback
- 変更ファイル群をこのPR前のcommitへ巻き戻す。