### PR TITLE
fix(tests+sources): eliminate remaining pytest warnings

### DIFF
--- a/jarvis_core/sources/pubmed_client.py
+++ b/jarvis_core/sources/pubmed_client.py
@@ -184,18 +184,18 @@ class PubMedClient:
         article = medline.find("Article") if medline is not None else None
 
         # PMID
-        pmid_elem = medline.find("PMID") if medline else None
+        pmid_elem = medline.find("PMID") if medline is not None else None
         pmid = pmid_elem.text if pmid_elem is not None else ""
 
         # Title
-        title_elem = article.find("ArticleTitle") if article else None
+        title_elem = article.find("ArticleTitle") if article is not None else None
         title = title_elem.text if title_elem is not None else ""
 
         # Abstract
         abstract_parts = []
-        if article:
+        if article is not None:
             abstract_elem = article.find("Abstract")
-            if abstract_elem:
+            if abstract_elem is not None:
                 for text in abstract_elem.findall("AbstractText"):
                     label = text.get("Label", "")
                     content = text.text or ""
@@ -207,9 +207,9 @@ class PubMedClient:
 
         # Authors
         authors = []
-        if article:
+        if article is not None:
             author_list = article.find("AuthorList")
-            if author_list:
+            if author_list is not None:
                 for author in author_list.findall("Author"):
                     last = author.find("LastName")
                     first = author.find("ForeName")
@@ -221,16 +221,16 @@ class PubMedClient:
 
         # Journal
         journal = ""
-        if article:
+        if article is not None:
             journal_elem = article.find("Journal/Title")
             if journal_elem is not None:
                 journal = journal_elem.text or ""
 
         # Date
         pub_date = ""
-        if article:
+        if article is not None:
             date_elem = article.find("Journal/JournalIssue/PubDate")
-            if date_elem:
+            if date_elem is not None:
                 year = date_elem.find("Year")
                 month = date_elem.find("Month")
                 if year is not None:
@@ -240,7 +240,7 @@ class PubMedClient:
 
         # DOI
         doi = None
-        if article:
+        if article is not None:
             for id_elem in article.findall("ELocationID"):
                 if id_elem.get("EIdType") == "doi":
                     doi = id_elem.text
@@ -248,9 +248,9 @@ class PubMedClient:
 
         # MeSH terms
         mesh_terms = []
-        if medline:
+        if medline is not None:
             mesh_list = medline.find("MeshHeadingList")
-            if mesh_list:
+            if mesh_list is not None:
                 for mesh in mesh_list.findall("MeshHeading/DescriptorName"):
                     if mesh.text:
                         mesh_terms.append(mesh.text)

--- a/tests/test_phaseM9_more_subpackages.py
+++ b/tests/test_phaseM9_more_subpackages.py
@@ -66,7 +66,7 @@ class TestSyncModules:
                     for method in dir(instance):
                         if not method.startswith("_") and callable(getattr(instance, method)):
                             try:
-                                getattr(instance, method)("key", "value")
+                                getattr(instance, method)("key")
                             except Exception:
                                 pass
                 except Exception:
@@ -158,7 +158,7 @@ class TestCacheModules:
                     for method in dir(instance):
                         if not method.startswith("_") and callable(getattr(instance, method)):
                             try:
-                                getattr(instance, method)("key", "value")
+                                getattr(instance, method)("key")
                             except Exception:
                                 pass
                 except Exception:


### PR DESCRIPTION
## Goal
pubmed XML判定とテスト由来のdeprecation/runtime warningを解消する。

## Non-Goal
機能追加や仕様変更は行わない。

## Changes
- pubmed_client の XML要素 truth-value 判定を is not None ベースへ統一
- 	est_phaseH21_25_more で未await coroutine warningを抑止
- 	est_phaseM9_more_subpackages の pathlib多引数deprecationを回避

## Tests
- uv run pytest tests/test_pubmed_client.py tests/test_phaseH21_25_more.py tests/test_phaseM9_more_subpackages.py -q -W error::DeprecationWarning
- uv run ruff check jarvis_core tests
- uv run black --check jarvis_core tests

## Rollback
- 対象3ファイルをこのPR前のcommitへ戻す。