### PR TITLE
chore(ops): enforce paper-alert close policy

### DIFF
--- a/.github/workflows/close-stale-alerts.yml
+++ b/.github/workflows/close-stale-alerts.yml
@@ -2,7 +2,10 @@ name: Close Stale Paper Alerts
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
 
 jobs:
   close-stale:


### PR DESCRIPTION
## Goal
paper-alert運用を『最新1件維持』に固定し、古い自動Issueの滞留を防ぐ。

## Non-Goal
paper-alert生成ロジック自体の仕様変更は行わない。

## Changes
- close-stale-alerts を日次実行へ変更
- workflow permissions に issues: write を明示
- 既存の古い paper-alert Issue (#103 #102 #101 #89 #88) をクローズ

## Validation
- gh issue list --state open --label paper-alert --limit 20 で open が最新1件のみ

## Rollback
- workflow schedule/permissions を元に戻す。