### PR TITLE
feat(ops_extract): implement vMASTER-Δ2.0 (strict closure, drive audit, telemetry dashboard)

### DIFF
--- a/docs/PLANS/QUALITY_HARDENING_FINAL_2026-02-14.md
+++ b/docs/PLANS/QUALITY_HARDENING_FINAL_2026-02-14.md
@@ -1,4 +1,6 @@
-﻿> Authority: ROADMAP (Level 5, Non-binding)`r`n`r`n# Quality Hardening Final Report (2026-02-14)
+﻿> Authority: ROADMAP (Level 5, Non-binding)
+
+# Quality Hardening Final Report (2026-02-14)
 
 ## 1. 結論
 - `ops_extract` を含む全体品質負債ゼロ化フェーズを完了。
@@ -72,4 +74,5 @@
 ## 6. 変更の安全性
 - 破壊的リファクタは未実施（差分修正のみ）。
 - `ops_extract` の P1-P6 成果を維持したまま、warning/error耐性と運用品質のみを改善。
+
 

--- a/docs/PLANS/VMASTER_DELTA2_IMPLEMENTATION_RESULT_2026-02-15.md
+++ b/docs/PLANS/VMASTER_DELTA2_IMPLEMENTATION_RESULT_2026-02-15.md
@@ -1,0 +1,91 @@
+﻿> Authority: DECISIONS (Level 2, Binding)
+
+# vMASTER-Δ2.0 Implementation Result
+
+- Date: 2026-02-15 01:52:26 +09:00
+- Branch: `feat/vmaster-delta2-opsextract`
+- Scope: `vMASTER-Δ2.0` (G1/G2/G3 + P0-P6)
+
+## 1. 実装結果
+
+### G1: 契約の最終矛盾（crash_dumpタイミング）
+- `validate_run_contracts_strict(..., assume_failed: bool = False)` を追加
+- `orchestrator` で contract error 発生時に `crash_dump.json` 出力後の再検証を追加
+- 再検証で `missing:crash_dump.json` 以外の残差がある場合、`crash_dump.json` に `post_contract_validation_errors` を追記
+
+### G2: Drive post-audit
+- `jarvis_core/ops_extract/drive_audit.py` を追加
+- `manifest.outputs` を基準に remote 存在・size・md5 を監査
+- `drive_sync` で `remote_root_folder_id` を `sync_state.json` に保存
+- `javisctl audit` を `--run-id` / `--run-dir` 対応へ拡張
+
+### G3: telemetry / progress / ETA / dashboard
+- 追加: `jarvis_core/ops_extract/telemetry/{models,sampler,progress,eta}.py`
+- `orchestrator` に telemetry/progress emit を統合（finally で sampler 停止）
+- fixed-time モードでは determinism 維持のため telemetry/progress を抑止
+- 追加: `jarvis_core/ops_extract/dashboard/app.py`（Streamlit + Plotly）
+- 追加: `scripts/javis_dashboard.py`
+- 追加: `javisctl dashboard`
+- `pyproject.toml` に optional extras `dashboard` を追加
+
+### P5: 論文サーベイ進捗％（canonical + cli_v4）
+- `run_literature_to_plan(..., progress_emitter=None)` を追加
+- `cli_v4` から ProgressEmitter を渡し、4 stage を記録
+  - `survey_discover`
+  - `survey_download`
+  - `survey_parse`
+  - `survey_index`
+
+### P0: 変更前自己診断
+- 追加: `scripts/audit_repo_state.py`
+- 追加: `tests/ops_extract/test_audit_repo_state_runs.py`
+- 出力: `reports/audit_repo_state.md`
+
+## 2. 追加/更新テスト（今回差分）
+- `tests/ops_extract/test_audit_repo_state_runs.py`
+- `tests/ops_extract/test_contract_strict_assume_failed_requires_crash_dump.py`
+- `tests/e2e/test_drive_audit_detects_missing.py`
+- `tests/ops_extract/test_progress_emitter_writes_jsonl.py`
+- `tests/ops_extract/test_telemetry_sampler_graceful_without_psutil.py`
+- `tests/literature/test_survey_emits_progress.py`
+
+## 3. 実行ログ（事実）
+- `uv run pytest -q`
+  - Result: `6502 passed, 469 skipped`
+- `uv run pytest tests/ops_extract tests/e2e/test_ops_extract_proof_driven.py -q`
+  - Result: `80 passed, 1 skipped`
+- `uv run ruff check jarvis_core tests scripts`
+  - Result: Pass
+- `uv run black --check jarvis_core tests scripts`
+  - Result: Pass
+- `uv run python -m build`
+  - Result: Pass
+- `uv run python tools/spec_lint.py`
+  - Result: `Checked 8 files / PASS`
+- `uv run python scripts/security_gate.py`
+  - Result: Fail（`pip-audit` 実行中の外部通信断: `ConnectionResetError WinError 10054`）
+
+## 4. 事実ベーススコア
+
+### 4.1 Gate Score
+- 評価対象ゲート: 7
+  - pytest(full), pytest(ops_extract), ruff, black, build, spec_lint, security_gate
+- Pass: 6
+- Fail: 1
+- Score: **85.7 / 100**
+
+### 4.2 vMASTER-Δ2.0 Goal Score
+- G1: 完了
+- G2: 完了
+- G3: 完了
+- Score: **3 / 3 (100%)**
+
+## 5. 残課題
+- `security_gate` の `pip-audit` がネットワーク要因で不安定
+- 本体コード不整合ではなく外部到達性が要因
+- 対応候補:
+  - `pip-audit` への retry/backoff 導入
+  - CI での PyPI 到達性チェック先行
+
+## 6. 補足
+- Spec Lint failure の原因だった `docs/PLANS/QUALITY_HARDENING_FINAL_2026-02-14.md` の Authority Header 改行崩れを修正済み。

--- a/jarvis_core/ops_extract/__init__.py
+++ b/jarvis_core/ops_extract/__init__.py
@@ -14,6 +14,7 @@ from .contracts import (
     build_ops_extract_config,
 )
 from .drive_client import DriveResumableClient, DriveUploadError
+from .drive_audit import audit_manifest_vs_drive
 from .drive_repair import plan_duplicate_folder_repair, repair_duplicate_folders
 from .failure_analysis import build_failure_analysis, classify_failure_category
 from .drive_sync import sync_run_to_drive
@@ -50,6 +51,7 @@ from .stage_cache import (
 )
 from .sync_queue import enqueue_sync_request, load_sync_queue, mark_sync_queue_state
 from .doctor import run_doctor
+from .telemetry import ETAEstimator, ProgressEmitter, TelemetrySampler
 from .scoreboard import (
     compute_extract_score,
     compute_ops_score,
@@ -69,6 +71,7 @@ __all__ = [
     "build_failure_analysis",
     "DriveResumableClient",
     "DriveUploadError",
+    "audit_manifest_vs_drive",
     "plan_duplicate_folder_repair",
     "repair_duplicate_folders",
     "sync_run_to_drive",
@@ -108,6 +111,9 @@ __all__ = [
     "load_sync_queue",
     "mark_sync_queue_state",
     "run_doctor",
+    "ETAEstimator",
+    "ProgressEmitter",
+    "TelemetrySampler",
     "compute_ops_score",
     "compute_extract_score",
     "detect_anomalies",

--- a/jarvis_core/ops_extract/dashboard/__init__.py
+++ b/jarvis_core/ops_extract/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard package for ops_extract telemetry visualization."""

--- a/jarvis_core/ops_extract/dashboard/app.py
+++ b/jarvis_core/ops_extract/dashboard/app.py
@@ -1,0 +1,183 @@
+"""Streamlit dashboard for ops_extract telemetry/progress."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import plotly.graph_objects as go
+import streamlit as st
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--run-dir", default="")
+    parser.add_argument("--run-id", default="")
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def _resolve_run_dir(args: argparse.Namespace) -> Path:
+    if args.run_dir:
+        return Path(args.run_dir)
+    if args.run_id:
+        return Path("logs") / "runs" / str(args.run_id)
+    return Path("logs") / "runs"
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    for raw in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not raw.strip():
+            continue
+        try:
+            row = json.loads(raw)
+        except Exception:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _format_eta(seconds: float | None) -> str:
+    if seconds is None:
+        return "N/A"
+    value = max(0, int(seconds))
+    hh = value // 3600
+    mm = (value % 3600) // 60
+    ss = value % 60
+    return f"{hh:02d}:{mm:02d}:{ss:02d}"
+
+
+def _gauge(title: str, value: float, max_value: float = 100.0) -> go.Figure:
+    fig = go.Figure(
+        go.Indicator(
+            mode="gauge+number",
+            value=float(value),
+            title={"text": title},
+            gauge={"axis": {"range": [0, max_value]}},
+        )
+    )
+    fig.update_layout(height=260, margin={"t": 40, "b": 20, "l": 20, "r": 20})
+    return fig
+
+
+def _line(title: str, x: list[str], y_series: list[tuple[str, list[float]]]) -> go.Figure:
+    fig = go.Figure()
+    for name, values in y_series:
+        fig.add_trace(go.Scatter(x=x, y=values, mode="lines+markers", name=name))
+    fig.update_layout(
+        title=title,
+        height=320,
+        margin={"t": 60, "b": 30, "l": 30, "r": 20},
+        legend={"orientation": "h"},
+    )
+    return fig
+
+
+def main() -> None:
+    args = _parse_args()
+    run_dir = _resolve_run_dir(args)
+    st.set_page_config(page_title="OpsExtract Dashboard", layout="wide")
+    st.title("OpsExtract Runtime Dashboard")
+    st.caption(f"run_dir: {run_dir}")
+    if hasattr(st, "autorefresh"):
+        st.autorefresh(interval=1000, key="ops_extract_dashboard_refresh")
+
+    telemetry = _load_jsonl(run_dir / "telemetry.jsonl")
+    progress = _load_jsonl(run_dir / "progress.jsonl")
+
+    if not telemetry and not progress:
+        st.warning("telemetry/progress data not found yet")
+        return
+
+    latest_tel = telemetry[-1] if telemetry else {}
+    latest_prog = progress[-1] if progress else {}
+
+    col_a, col_b, col_c = st.columns(3)
+    with col_a:
+        st.plotly_chart(
+            _gauge("Crash Risk %", float(latest_tel.get("crash_risk_percent", 0.0))),
+            use_container_width=True,
+        )
+    with col_b:
+        st.plotly_chart(
+            _gauge("Overall Progress %", float(latest_prog.get("overall_progress_percent", 0.0))),
+            use_container_width=True,
+        )
+    with col_c:
+        st.plotly_chart(
+            _gauge("Stage Progress %", float(latest_prog.get("stage_progress_percent", 0.0))),
+            use_container_width=True,
+        )
+
+    col_eta1, col_eta2 = st.columns(2)
+    with col_eta1:
+        st.metric("ETA", _format_eta(latest_prog.get("eta_seconds")))
+    with col_eta2:
+        st.metric(
+            "ETA Confidence %", f"{float(latest_prog.get('eta_confidence_percent', 0.0)):.1f}"
+        )
+
+    if telemetry:
+        tx = [str(row.get("ts_iso", "")) for row in telemetry]
+        sent_mb = [
+            float(row.get("net_sent_bytes_total", 0)) / (1024.0 * 1024.0) for row in telemetry
+        ]
+        recv_mb = [
+            float(row.get("net_recv_bytes_total", 0)) / (1024.0 * 1024.0) for row in telemetry
+        ]
+        sent_kbps = [float(row.get("net_sent_bps", 0)) / 1024.0 for row in telemetry]
+        recv_kbps = [float(row.get("net_recv_bps", 0)) / 1024.0 for row in telemetry]
+        rss_mb = [float(row.get("rss_mb", 0)) for row in telemetry]
+        cpu = [float(row.get("cpu_percent", 0)) for row in telemetry]
+
+        st.plotly_chart(
+            _line("Network Cumulative (MB)", tx, [("sent_mb", sent_mb), ("recv_mb", recv_mb)]),
+            use_container_width=True,
+        )
+        st.plotly_chart(
+            _line(
+                "Network Throughput (KB/s)",
+                tx,
+                [("sent_kbps", sent_kbps), ("recv_kbps", recv_kbps)],
+            ),
+            use_container_width=True,
+        )
+        st.plotly_chart(
+            _line("Memory/CPU", tx, [("rss_mb", rss_mb), ("cpu_percent", cpu)]),
+            use_container_width=True,
+        )
+
+    if progress:
+        px = [str(row.get("ts_iso", "")) for row in progress]
+        overall = [float(row.get("overall_progress_percent", 0)) for row in progress]
+        stage = [float(row.get("stage_progress_percent", 0)) for row in progress]
+        st.plotly_chart(
+            _line("Progress Timeline", px, [("overall_%", overall), ("stage_%", stage)]),
+            use_container_width=True,
+        )
+
+        # stage timeline (simple bar of latest stage max progress)
+        stage_latest: dict[str, float] = {}
+        for row in progress:
+            stage_name = str(row.get("stage", ""))
+            stage_latest[stage_name] = max(
+                stage_latest.get(stage_name, 0.0), float(row.get("stage_progress_percent", 0))
+            )
+        fig = go.Figure(
+            go.Bar(
+                x=list(stage_latest.keys()),
+                y=list(stage_latest.values()),
+                marker_color="#4c78a8",
+            )
+        )
+        fig.update_layout(title="Stage Progress Snapshot", yaxis={"range": [0, 100]}, height=320)
+        st.plotly_chart(fig, use_container_width=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis_core/ops_extract/drive_audit.py
+++ b/jarvis_core/ops_extract/drive_audit.py
@@ -1,0 +1,144 @@
+"""Post-sync Drive audit utilities for ops_extract."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .contracts import OPS_EXTRACT_SCHEMA_VERSION
+from .drive_client import DriveResumableClient
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _md5(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.md5(usedforsecurity=False)
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_folder(item: dict[str, Any]) -> bool:
+    mime_type = str(item.get("mimeType", "")).strip().lower()
+    return mime_type == "application/vnd.google-apps.folder" or bool(item.get("folder"))
+
+
+def _collect_remote_entries(
+    client: DriveResumableClient,
+    root_folder_id: str,
+) -> dict[str, dict[str, Any]]:
+    remote_files: dict[str, dict[str, Any]] = {}
+    stack: list[tuple[str, str]] = [(root_folder_id, "")]
+    visited: set[str] = set()
+    while stack:
+        parent_id, prefix = stack.pop()
+        if parent_id in visited:
+            continue
+        visited.add(parent_id)
+        children = client.list_children(
+            parent_id=parent_id,
+            q=None,
+            fields="files(id,name,mimeType,size,md5Checksum,modifiedTime)",
+        )
+        for child in children:
+            if not isinstance(child, dict):
+                continue
+            name = str(child.get("name", "")).strip()
+            if not name:
+                continue
+            rel = f"{prefix}/{name}" if prefix else name
+            if _is_folder(child):
+                child_id = str(child.get("id", "")).strip()
+                if child_id:
+                    stack.append((child_id, rel))
+                continue
+            remote_files[rel] = child
+    return remote_files
+
+
+def audit_manifest_vs_drive(
+    run_dir: Path,
+    client: DriveResumableClient,
+    folder_id: str,
+) -> dict[str, Any]:
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"manifest_not_found:{manifest_path}")
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest_payload, dict):
+        raise RuntimeError("manifest_payload_invalid")
+
+    outputs = manifest_payload.get("outputs", [])
+    if not isinstance(outputs, list):
+        outputs = []
+    remote_entries = _collect_remote_entries(client, folder_id)
+
+    missing: list[str] = []
+    mismatch_size: list[str] = []
+    mismatch_md5: list[str] = []
+    remote_no_md5: list[str] = []
+    checked_paths: list[str] = []
+
+    for row in outputs:
+        if not isinstance(row, dict):
+            continue
+        rel = str(row.get("path", "")).strip()
+        if not rel:
+            continue
+        checked_paths.append(rel)
+        remote = remote_entries.get(rel)
+        if remote is None:
+            missing.append(rel)
+            continue
+        remote_meta = dict(remote)
+        remote_id = str(remote_meta.get("id", "")).strip()
+        if remote_id:
+            try:
+                fetched = client.get_file_metadata(
+                    remote_id,
+                    fields="id,size,md5Checksum,modifiedTime,name",
+                )
+                if isinstance(fetched, dict) and fetched:
+                    remote_meta.update(fetched)
+            except Exception:
+                pass
+
+        expected_size = row.get("size")
+        try:
+            if expected_size is not None and int(remote_meta.get("size", -1)) != int(expected_size):
+                mismatch_size.append(rel)
+        except Exception:
+            mismatch_size.append(rel)
+
+        remote_md5 = str(remote_meta.get("md5Checksum", "")).strip().lower()
+        local_path = run_dir / rel
+        expected_md5 = (
+            _md5(local_path).lower() if local_path.exists() and local_path.is_file() else ""
+        )
+        if remote_md5:
+            if expected_md5 and remote_md5 != expected_md5:
+                mismatch_md5.append(rel)
+        else:
+            remote_no_md5.append(rel)
+
+    report = {
+        "schema_version": OPS_EXTRACT_SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "folder_id": folder_id,
+        "checked_count": len(checked_paths),
+        "missing": sorted(set(missing)),
+        "mismatch_size": sorted(set(mismatch_size)),
+        "mismatch_md5": sorted(set(mismatch_md5)),
+        "remote_no_md5": sorted(set(remote_no_md5)),
+        "ok": not (missing or mismatch_size or mismatch_md5),
+    }
+    out_path = run_dir / "drive_audit.json"
+    out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    return report

--- a/jarvis_core/ops_extract/drive_sync.py
+++ b/jarvis_core/ops_extract/drive_sync.py
@@ -457,6 +457,7 @@ def sync_run_to_drive(
             "last_error": "",
             "dry_run": dry_run,
             "manifest_committed_drive": False,
+            "remote_root_folder_id": "",
             "last_attempt_at": _now(),
         }
         _write_sync_state(sync_state_path, payload)
@@ -503,6 +504,7 @@ def sync_run_to_drive(
         "last_error": "",
         "dry_run": dry_run,
         "manifest_committed_drive": False,
+        "remote_root_folder_id": str(previous.get("remote_root_folder_id", "") or ""),
         "last_attempt_at": _now(),
     }
     if manifest_fallback:
@@ -518,6 +520,7 @@ def sync_run_to_drive(
         state["manifest_committed_drive"] = True
         state["pending_files"] = []
         state["committed_at"] = previous.get("committed_at") or _now()
+        state["remote_root_folder_id"] = str(previous.get("remote_root_folder_id", "") or "")
         _write_sync_state(sync_state_path, state)
         return state
 
@@ -539,6 +542,7 @@ def sync_run_to_drive(
                 state["state"] = "deferred"
                 state["last_error"] = "sync_lock_conflict"
                 state["pending_files"] = [{"path": rel} for rel in pending]
+                state["remote_root_folder_id"] = str(state.get("remote_root_folder_id", "") or "")
                 state["last_attempt_at"] = _now()
                 _write_sync_state(sync_state_path, state)
                 return state
@@ -583,6 +587,7 @@ def sync_run_to_drive(
                 )
                 root_upload_folder_id = folder_id
                 folder_cache[""] = root_upload_folder_id
+        state["remote_root_folder_id"] = str(root_upload_folder_id or "")
 
         if (
             client is not None
@@ -729,6 +734,7 @@ def sync_run_to_drive(
         state["pending_files"] = []
         state["failed_files"] = []
         state["manifest_committed_drive"] = True
+        state["remote_root_folder_id"] = str(root_upload_folder_id or "")
         state["committed_at"] = _now()
         state["last_attempt_at"] = _now()
         _write_sync_state(sync_state_path, state)
@@ -754,6 +760,7 @@ def sync_run_to_drive(
             else [{"path": rel, "error": message} for rel in remaining[:1]]
         )
         state["manifest_committed_drive"] = False
+        state["remote_root_folder_id"] = str(state.get("remote_root_folder_id", "") or "")
         state["last_attempt_at"] = _now()
         _write_sync_state(sync_state_path, state)
         return state

--- a/jarvis_core/ops_extract/schema_validate.py
+++ b/jarvis_core/ops_extract/schema_validate.py
@@ -152,12 +152,14 @@ def _count_non_empty_jsonl_lines(path: Path) -> int:
     return count
 
 
-def validate_run_contracts_strict(run_dir: Path, *, include_ocr_meta: bool) -> list[str]:
+def validate_run_contracts_strict(
+    run_dir: Path, *, include_ocr_meta: bool, assume_failed: bool = False
+) -> list[str]:
     errors: list[str] = []
 
     expected = list_expected_contract_files(include_ocr_meta=include_ocr_meta)
     status = _read_run_status(run_dir)
-    if status == "failed":
+    if assume_failed or status == "failed":
         expected.append("crash_dump.json")
 
     for filename in expected:

--- a/jarvis_core/ops_extract/telemetry/__init__.py
+++ b/jarvis_core/ops_extract/telemetry/__init__.py
@@ -1,0 +1,14 @@
+"""Telemetry components for ops_extract runtime monitoring."""
+
+from .eta import ETAEstimator
+from .models import ProgressPoint, TelemetryPoint
+from .progress import ProgressEmitter
+from .sampler import TelemetrySampler
+
+__all__ = [
+    "ETAEstimator",
+    "ProgressPoint",
+    "TelemetryPoint",
+    "ProgressEmitter",
+    "TelemetrySampler",
+]

--- a/jarvis_core/ops_extract/telemetry/eta.py
+++ b/jarvis_core/ops_extract/telemetry/eta.py
@@ -1,0 +1,78 @@
+"""ETA estimator for ops_extract progress telemetry."""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+
+class ETAEstimator:
+    """Estimate remaining runtime and confidence using history + current pace."""
+
+    def __init__(self, runs_base: Path | None = None) -> None:
+        self.runs_base = Path(runs_base) if runs_base else None
+        self._history_seconds = self._load_history_seconds(limit=400)
+
+    def _load_history_seconds(self, *, limit: int) -> list[float]:
+        if not self.runs_base or not self.runs_base.exists():
+            return []
+        durations: list[float] = []
+        for metrics_path in sorted(self.runs_base.glob("*/metrics.json"), reverse=True):
+            try:
+                payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            value = payload.get("run_duration_sec")
+            try:
+                dur = float(value)
+            except Exception:
+                continue
+            if dur > 0:
+                durations.append(dur)
+            if len(durations) >= limit:
+                break
+        return durations
+
+    def estimate(
+        self,
+        *,
+        elapsed_seconds: float,
+        overall_progress_percent: float,
+    ) -> tuple[float | None, float]:
+        progress = max(0.0, min(100.0, float(overall_progress_percent)))
+        elapsed = max(0.0, float(elapsed_seconds))
+        if progress <= 0.0:
+            return None, self._confidence()
+
+        pace_eta = elapsed * (100.0 - progress) / progress
+        history = self._history_seconds
+        if not history:
+            return pace_eta, 45.0
+
+        baseline_total = statistics.median(history)
+        baseline_eta = baseline_total * (100.0 - progress) / 100.0
+        eta_seconds = (pace_eta * 0.7) + (baseline_eta * 0.3)
+        return max(0.0, eta_seconds), self._confidence()
+
+    def _confidence(self) -> float:
+        history = self._history_seconds
+        n = len(history)
+        if n == 0:
+            return 35.0
+        if n == 1:
+            return 45.0
+        mean = sum(history) / n
+        if mean <= 0:
+            return 40.0
+        try:
+            std = statistics.pstdev(history)
+        except Exception:
+            std = 0.0
+        cv = std / mean if mean else 1.0
+        sample_score = min(1.0, n / 20.0)
+        variance_score = max(0.0, 1.0 - min(1.0, cv))
+        confidence = (0.6 * sample_score + 0.4 * variance_score) * 100.0
+        return round(max(20.0, min(95.0, confidence)), 2)

--- a/jarvis_core/ops_extract/telemetry/models.py
+++ b/jarvis_core/ops_extract/telemetry/models.py
@@ -1,0 +1,30 @@
+"""Telemetry models for ops_extract runtime monitoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TelemetryPoint:
+    ts_iso: str
+    net_sent_bytes_total: int
+    net_recv_bytes_total: int
+    net_sent_bps: float
+    net_recv_bps: float
+    rss_mb: float
+    vms_mb: float
+    cpu_percent: float
+    crash_risk_percent: float
+
+
+@dataclass(frozen=True)
+class ProgressPoint:
+    ts_iso: str
+    stage: str
+    stage_progress_percent: float
+    overall_progress_percent: float
+    items_done: int
+    items_total: int
+    eta_seconds: float | None
+    eta_confidence_percent: float

--- a/jarvis_core/ops_extract/telemetry/progress.py
+++ b/jarvis_core/ops_extract/telemetry/progress.py
@@ -1,0 +1,139 @@
+"""Progress emitter for ops_extract and related workflows."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .eta import ETAEstimator
+from .models import ProgressPoint
+
+
+STAGE_WEIGHT_MAP = {
+    "preflight": 5.0,
+    "ingest": 10.0,
+    "ocr": 25.0,
+    "extract": 25.0,
+    "sync": 20.0,
+    "retention_report": 15.0,
+}
+
+STAGE_CATEGORY_MAP = {
+    "preflight": "preflight",
+    "discover_inputs": "ingest",
+    "extract_text_pdf": "extract",
+    "needs_ocr_decision": "ocr",
+    "rasterize_pdf": "ocr",
+    "ocr_yomitoku": "ocr",
+    "normalize_text": "extract",
+    "extract_figures_tables": "extract",
+    "compute_metrics_warnings": "extract",
+    "write_contract_files": "extract",
+    "enqueue_drive_sync": "sync",
+    "retention_mark": "retention_report",
+    "survey_discover": "ingest",
+    "survey_download": "sync",
+    "survey_parse": "extract",
+    "survey_index": "extract",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ProgressEmitter:
+    """Append progress points to progress.jsonl with weighted overall progress."""
+
+    def __init__(
+        self,
+        run_dir: Path,
+        *,
+        eta_estimator: ETAEstimator | None = None,
+        filename: str = "progress.jsonl",
+    ) -> None:
+        self.run_dir = Path(run_dir)
+        self.path = self.run_dir / filename
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.eta = eta_estimator or ETAEstimator(
+            self.run_dir.parent if self.run_dir.parent else None
+        )
+        self._run_started = time.perf_counter()
+        self._stage_state: dict[str, dict[str, Any]] = {}
+        self._category_progress = {key: 0.0 for key in STAGE_WEIGHT_MAP}
+
+    def emit_stage_start(self, stage: str, items_total: int | None = None) -> None:
+        total = int(items_total) if items_total is not None and int(items_total) > 0 else 0
+        self._stage_state[stage] = {
+            "items_done": 0,
+            "items_total": total,
+            "progress": 0.0,
+        }
+        self._emit(stage)
+
+    def emit_stage_update(
+        self, stage: str, items_done: int, items_total: int | None = None
+    ) -> None:
+        state = self._stage_state.setdefault(
+            stage, {"items_done": 0, "items_total": 0, "progress": 0.0}
+        )
+        if items_total is not None and int(items_total) > 0:
+            state["items_total"] = int(items_total)
+        state["items_done"] = max(0, int(items_done))
+        total = int(state.get("items_total", 0))
+        if total > 0:
+            stage_progress = min(100.0, max(0.0, (state["items_done"] / total) * 100.0))
+        else:
+            # Fallback when total is unknown: monotonic coarse progress.
+            stage_progress = min(99.0, float(state.get("progress", 0.0)) + 5.0)
+        state["progress"] = stage_progress
+        self._emit(stage)
+
+    def emit_stage_end(self, stage: str) -> None:
+        state = self._stage_state.setdefault(
+            stage, {"items_done": 0, "items_total": 0, "progress": 0.0}
+        )
+        total = int(state.get("items_total", 0))
+        if total <= 0:
+            total = max(1, int(state.get("items_done", 0)))
+            state["items_total"] = total
+        state["items_done"] = total
+        state["progress"] = 100.0
+        self._emit(stage)
+
+    def _emit(self, stage: str) -> None:
+        state = self._stage_state.get(stage, {"items_done": 0, "items_total": 0, "progress": 0.0})
+        stage_progress = float(state.get("progress", 0.0))
+        category = STAGE_CATEGORY_MAP.get(stage, "extract")
+        self._category_progress[category] = max(
+            self._category_progress.get(category, 0.0), stage_progress
+        )
+        overall = self._overall_progress()
+        elapsed = max(0.0, time.perf_counter() - self._run_started)
+        eta_seconds, eta_confidence = self.eta.estimate(
+            elapsed_seconds=elapsed,
+            overall_progress_percent=overall,
+        )
+
+        point = ProgressPoint(
+            ts_iso=_now_iso(),
+            stage=stage,
+            stage_progress_percent=round(stage_progress, 4),
+            overall_progress_percent=round(overall, 4),
+            items_done=int(state.get("items_done", 0)),
+            items_total=int(state.get("items_total", 0)),
+            eta_seconds=(round(eta_seconds, 4) if eta_seconds is not None else None),
+            eta_confidence_percent=round(eta_confidence, 2),
+        )
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(point.__dict__, ensure_ascii=False) + "\n")
+
+    def _overall_progress(self) -> float:
+        total = 0.0
+        for category, weight in STAGE_WEIGHT_MAP.items():
+            progress = max(0.0, min(100.0, float(self._category_progress.get(category, 0.0))))
+            total += weight * (progress / 100.0)
+        return max(0.0, min(100.0, total))

--- a/jarvis_core/ops_extract/telemetry/sampler.py
+++ b/jarvis_core/ops_extract/telemetry/sampler.py
@@ -1,0 +1,126 @@
+"""Telemetry sampler for ops_extract runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from .models import TelemetryPoint
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TelemetrySampler:
+    """Background sampler that appends telemetry points to telemetry.jsonl."""
+
+    def __init__(
+        self,
+        run_dir: Path,
+        *,
+        interval_sec: float = 0.5,
+        recent_exceptions_count_fn: Callable[[], int] | None = None,
+    ) -> None:
+        self.run_dir = Path(run_dir)
+        self.interval_sec = max(0.1, float(interval_sec))
+        self.path = self.run_dir / "telemetry.jsonl"
+        self._recent_exceptions_count_fn = recent_exceptions_count_fn or (lambda: 0)
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._enabled = True
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        try:
+            import psutil  # type: ignore
+        except Exception:
+            self._enabled = False
+            return
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            kwargs={"psutil_mod": psutil},
+            daemon=True,
+            name="ops_extract_telemetry",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2.0)
+
+    def __del__(self) -> None:  # pragma: no cover
+        try:
+            self.stop()
+        except Exception:
+            pass
+
+    def _run_loop(self, *, psutil_mod) -> None:
+        process = psutil_mod.Process(os.getpid())
+        prev = psutil_mod.net_io_counters()
+        prev_ts = time.perf_counter()
+        # Prime CPU percent baseline.
+        process.cpu_percent(interval=None)
+        while not self._stop.is_set():
+            time.sleep(self.interval_sec)
+            now = psutil_mod.net_io_counters()
+            now_ts = time.perf_counter()
+            dt = max(1e-6, now_ts - prev_ts)
+            sent_bps = float(now.bytes_sent - prev.bytes_sent) / dt
+            recv_bps = float(now.bytes_recv - prev.bytes_recv) / dt
+            prev = now
+            prev_ts = now_ts
+
+            mem = process.memory_info()
+            vm = psutil_mod.virtual_memory()
+            rss_mb = float(mem.rss) / (1024.0 * 1024.0)
+            vms_mb = float(mem.vms) / (1024.0 * 1024.0)
+            cpu_percent = float(process.cpu_percent(interval=None))
+            available_mb = max(1.0, float(vm.available) / (1024.0 * 1024.0))
+            mem_ratio = rss_mb / available_mb
+            risk = self._crash_risk_percent(mem_ratio=mem_ratio)
+            try:
+                recent_ex = int(self._recent_exceptions_count_fn())
+            except Exception:
+                recent_ex = 0
+            if recent_ex > 0:
+                risk = min(100.0, risk + 10.0)
+
+            point = TelemetryPoint(
+                ts_iso=_now_iso(),
+                net_sent_bytes_total=int(now.bytes_sent),
+                net_recv_bytes_total=int(now.bytes_recv),
+                net_sent_bps=round(sent_bps, 4),
+                net_recv_bps=round(recv_bps, 4),
+                rss_mb=round(rss_mb, 4),
+                vms_mb=round(vms_mb, 4),
+                cpu_percent=round(cpu_percent, 4),
+                crash_risk_percent=round(risk, 2),
+            )
+            with open(self.path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(point.__dict__, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _crash_risk_percent(*, mem_ratio: float) -> float:
+        if mem_ratio < 0.5:
+            return 5.0
+        if mem_ratio < 0.7:
+            return 20.0
+        if mem_ratio < 0.85:
+            return 50.0
+        if mem_ratio < 0.93:
+            return 75.0
+        return 90.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ web = [
 browser = [
     "playwright>=1.40",
 ]
+dashboard = [
+    "streamlit>=1.32",
+    "plotly>=5.20",
+    "psutil>=5.9",
+]
 mcp = [
     "httpx>=0.25",
 ]
@@ -89,7 +94,7 @@ dev = [
     "bandit>=1.7.0",
 ]
 all = [
-    "jarvis-research-os[ml,pdf,llm,embedding,web,browser,mcp]",
+    "jarvis-research-os[ml,pdf,llm,embedding,web,browser,dashboard,mcp]",
 ]
 
 [dependency-groups]

--- a/scripts/analyze_test_failures.py
+++ b/scripts/analyze_test_failures.py
@@ -7,11 +7,15 @@ import re
 from pathlib import Path
 from collections import defaultdict
 
+
 def run_tests_and_collect_failures():
     """Run pytest and collect failure information."""
     result = subprocess.run(
         [
-            "uv", "run", "pytest", "tests/",
+            "uv",
+            "run",
+            "pytest",
+            "tests/",
             "--ignore=tests/e2e",
             "--ignore=tests/integration",
             "-v",
@@ -20,17 +24,18 @@ def run_tests_and_collect_failures():
             "--no-header",
             "-x",  # Stop on first failure for initial analysis
             "--collect-only",
-            "-q"
+            "-q",
         ],
         capture_output=True,
-        text=True
+        text=True,
     )
     return result
+
 
 def categorize_failures(output: str) -> dict:
     """Categorize failures by type."""
     categories = defaultdict(list)
-    
+
     patterns = {
         "import_error": r"ImportError|ModuleNotFoundError",
         "attribute_error": r"AttributeError",
@@ -43,14 +48,15 @@ def categorize_failures(output: str) -> dict:
         "fixture_error": r"fixture.*not found|FixtureLookupError",
         "mock_error": r"MagicMock|Mock.*called",
     }
-    
-    for line in output.split('\n'):
+
+    for line in output.split("\n"):
         for category, pattern in patterns.items():
             if re.search(pattern, line, re.IGNORECASE):
                 categories[category].append(line)
                 break
-    
+
     return dict(categories)
+
 
 def generate_fix_plan(categories: dict) -> dict:
     """Generate fix plan based on categories."""
@@ -60,108 +66,122 @@ def generate_fix_plan(categories: dict) -> dict:
         "priority_3_logic_fixes": [],
         "priority_4_skip_candidates": [],
     }
-    
+
     # Import errors - usually quick fixes
     if "import_error" in categories:
-        fix_plan["priority_1_quick_fixes"].extend([
-            "Check missing dependencies in pyproject.toml",
-            "Add conditional imports for optional dependencies",
-            "Fix circular imports"
-        ])
-    
+        fix_plan["priority_1_quick_fixes"].extend(
+            [
+                "Check missing dependencies in pyproject.toml",
+                "Add conditional imports for optional dependencies",
+                "Fix circular imports",
+            ]
+        )
+
     # Fixture errors - need conftest.py updates
     if "fixture_error" in categories:
-        fix_plan["priority_2_mock_fixes"].extend([
-            "Add missing fixtures to tests/conftest.py",
-            "Ensure fixture scope is correct",
-            "Add pytest plugins if needed"
-        ])
-    
+        fix_plan["priority_2_mock_fixes"].extend(
+            [
+                "Add missing fixtures to tests/conftest.py",
+                "Ensure fixture scope is correct",
+                "Add pytest plugins if needed",
+            ]
+        )
+
     # Connection errors - need mocking
     if "connection_error" in categories:
-        fix_plan["priority_2_mock_fixes"].extend([
-            "Mock external API calls",
-            "Add @pytest.mark.network decorator",
-            "Use responses or httpx_mock"
-        ])
-    
+        fix_plan["priority_2_mock_fixes"].extend(
+            [
+                "Mock external API calls",
+                "Add @pytest.mark.network decorator",
+                "Use responses or httpx_mock",
+            ]
+        )
+
     return fix_plan
+
 
 def main():
     print("=== JARVIS Test Failure Analyzer ===\n")
-    
+
     # Collect test list first
     print("Collecting test list...")
     result = subprocess.run(
         [
-            "uv", "run", "pytest", "tests/",
+            "uv",
+            "run",
+            "pytest",
+            "tests/",
             "--ignore=tests/e2e",
             "--ignore=tests/integration",
-            "--collect-only"
+            "--collect-only",
         ],
         capture_output=True,
-        text=True
+        text=True,
     )
-    
+
     # Count tests - more robust way
     test_count = 0
-    for line in result.stdout.split('\n'):
-        if '<Function' in line or '::' in line:
+    for line in result.stdout.split("\n"):
+        if "<Function" in line or "::" in line:
             test_count += 1
-    
+
     if test_count == 0:
         # Try finding "collected X items"
-        match = re.search(r'collected (\d+) items', result.stdout)
+        match = re.search(r"collected (\d+) items", result.stdout)
         if match:
             test_count = int(match.group(1))
-            
+
     print(f"Total tests found: {test_count}")
-    
+
     if result.stderr:
         print("\nCollection Warnings/Errors:")
         print(result.stderr[:500])
-    
+
     # Run actual tests
     print("\nRunning tests (this may take a while)...")
     # We run without -x to get more failures, but with --maxfail to avoid infinite run
     result = subprocess.run(
         [
-            "uv", "run", "pytest", "tests/",
+            "uv",
+            "run",
+            "pytest",
+            "tests/",
             "--ignore=tests/e2e",
             "--ignore=tests/integration",
             "-v",
             "--tb=line",
-            "--maxfail=100"
+            "--maxfail=100",
         ],
         capture_output=True,
-        text=True
+        text=True,
     )
-    
+
     # Analyze output
     full_output = result.stdout + result.stderr
     categories = categorize_failures(full_output)
-    
+
     print("\n=== Failure Categories ===")
     for category, items in categories.items():
         print(f"{category}: {len(items)} hits in output")
-    
+
     # Generate fix plan
     fix_plan = generate_fix_plan(categories)
-    
+
     # Save results
     output = {
         "total_tests": test_count,
         "categories": categories,
         "fix_plan": fix_plan,
-        "raw_output_snippet": full_output[:2000]
+        "raw_output_snippet": full_output[:2000],
     }
-    
+
     output_path = Path("artifacts/test_analysis.json")
     output_path.parent.mkdir(exist_ok=True)
-    with open(output_path, "w", encoding='utf-8') as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(output, f, indent=2)
-    
+
     print(f"\nResults saved to {output_path}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/audit_repo_state.py
+++ b/scripts/audit_repo_state.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Repository state audit for ops_extract proof-driven checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORT_PATH = ROOT / "reports" / "audit_repo_state.md"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def _contains_all(text: str, needles: Iterable[str]) -> bool:
+    return all(needle in text for needle in needles)
+
+
+def run_audit() -> list[CheckResult]:
+    schema_validate = _read(ROOT / "jarvis_core" / "ops_extract" / "schema_validate.py")
+    orchestrator = _read(ROOT / "jarvis_core" / "ops_extract" / "orchestrator.py")
+    drive_sync = _read(ROOT / "jarvis_core" / "ops_extract" / "drive_sync.py")
+    doctor = _read(ROOT / "jarvis_core" / "ops_extract" / "doctor.py")
+    preflight = _read(ROOT / "jarvis_core" / "ops_extract" / "preflight.py")
+
+    results: list[CheckResult] = []
+    results.append(
+        CheckResult(
+            name="validate_run_contracts_strict_exists",
+            status=(
+                "present" if "def validate_run_contracts_strict" in schema_validate else "missing"
+            ),
+            detail="schema_validate.py:def validate_run_contracts_strict",
+        )
+    )
+    results.append(
+        CheckResult(
+            name="orchestrator_calls_strict_validator",
+            status=(
+                "present"
+                if _contains_all(
+                    orchestrator, ("validate_run_contracts_strict(", "write_contract_files")
+                )
+                else "missing"
+            ),
+            detail="orchestrator.py uses strict contract validation in write_contract_files stage",
+        )
+    )
+    results.append(
+        CheckResult(
+            name="drive_sync_targets_manifest_outputs",
+            status=(
+                "present"
+                if _contains_all(drive_sync, ("def _target_files_from_manifest", "outputs", "path"))
+                else "missing"
+            ),
+            detail="drive_sync.py:_target_files_from_manifest references manifest outputs[].path",
+        )
+    )
+    results.append(
+        CheckResult(
+            name="doctor_has_next_commands_section",
+            status="present" if "## Next Commands" in doctor else "missing",
+            detail='doctor.py writes "## Next Commands"',
+        )
+    )
+    results.append(
+        CheckResult(
+            name="preflight_has_queue_backlog_hard_check",
+            status=(
+                "present"
+                if _contains_all(preflight, ('"check_sync_queue_backlog"', "hard=True"))
+                else "missing"
+            ),
+            detail="preflight.py executes check_sync_queue_backlog with hard=True",
+        )
+    )
+
+    telemetry_files = [
+        ROOT / "jarvis_core" / "ops_extract" / "telemetry" / "models.py",
+        ROOT / "jarvis_core" / "ops_extract" / "telemetry" / "sampler.py",
+        ROOT / "jarvis_core" / "ops_extract" / "telemetry" / "progress.py",
+        ROOT / "jarvis_core" / "ops_extract" / "telemetry" / "eta.py",
+    ]
+    for path in telemetry_files:
+        results.append(
+            CheckResult(
+                name=f"telemetry_file:{path.name}",
+                status="present" if path.exists() else "missing",
+                detail=str(path.relative_to(ROOT)),
+            )
+        )
+    return results
+
+
+def write_report(results: list[CheckResult]) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# OpsExtract Repository Audit",
+        "",
+        "| Check | Status | Detail |",
+        "|---|---|---|",
+    ]
+    for row in results:
+        lines.append(f"| {row.name} | {row.status} | {row.detail} |")
+    lines.append("")
+    lines.append(
+        f"Summary: present={sum(1 for r in results if r.status == 'present')} "
+        f"missing={sum(1 for r in results if r.status == 'missing')}"
+    )
+    REPORT_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    results = run_audit()
+    write_report(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_run.py
+++ b/scripts/ci_run.py
@@ -323,8 +323,6 @@ def generate_summary(
 def generate_manifest(run_id, query, status, run_dir, created_at, stats, pipeline_version, quality):
     """Artifact Contract v1に準拠したmanifest.jsonを生成"""
     run_path = Path(run_dir)
-    summary_path = run_path / "summary.json"
-    stats_path = run_path / "stats.json"
     meta_path = run_path / "raw" / "pubmed_metadata.json"
     logs_path = run_path / "logs.jsonl"
     report_path = run_path / "report.md"

--- a/scripts/detect_garbage_code.py
+++ b/scripts/detect_garbage_code.py
@@ -75,7 +75,10 @@ class GarbageDetector(ast.NodeVisitor):
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if len(node.body) == 1 and isinstance(node.body[0], ast.Pass):
-            if isinstance(node.type, ast.Name) and node.type.id in {"ImportError", "AttributeError"}:
+            if isinstance(node.type, ast.Name) and node.type.id in {
+                "ImportError",
+                "AttributeError",
+            }:
                 self.generic_visit(node)
                 return
             self.issues.append(f"{node.lineno}: {MSG_EXCEPT_PASS}")

--- a/scripts/find_dead_code.py
+++ b/scripts/find_dead_code.py
@@ -3,6 +3,7 @@
 import subprocess
 import sys
 
+
 def main():
     result = subprocess.run(
         [
@@ -11,7 +12,8 @@ def main():
             "vulture",
             "jarvis_core",
             "vulture_whitelist.py",
-            "--min-confidence", "80",
+            "--min-confidence",
+            "80",
         ],
         capture_output=True,
         text=True,
@@ -20,6 +22,7 @@ def main():
     if result.stderr:
         print(result.stderr, file=sys.stderr)
     return result.returncode
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/fix_bare_excepts.py
+++ b/scripts/fix_bare_excepts.py
@@ -1,43 +1,41 @@
 import re
 from pathlib import Path
 
+
 def fix_bare_excepts(directory: Path):
     # 'except:' を 'except Exception as e:' に置換し、次の行にログ出力を追加するパターン
     # ただし、すでに 'pass' などの単純な処理がある場合を想定して置換する
-    
-    # regex to find bare 'except:' and the following indentation
-    pattern = re.compile(r'^(\s*)except:(\s*)$', re.MULTILINE)
-    
+
     for py_file in directory.rglob("*.py"):
         if ".venv" in str(py_file) or "__pycache__" in str(py_file):
             continue
-            
+
         content = py_file.read_text(encoding="utf-8")
         if "except:" not in content:
             continue
-            
-        # 簡易的な置換: 
+
+        # 簡易的な置換:
         # except: -> except Exception as e:
         # 下の行が pass の場合はその手前にログを入れたいところだが
         # 既存のロジックを壊さないよう、単純に logging を導入するか検討が必要。
         # 指示書には「logger.warningを追加する」とある。
-        
+
         # ファイルごとに logger が import されているか確認するのは大変なので
         # とりあえず except Exception as e: への置換を優先する。
         # ログ出力は logger が存在することを前提とするか、print にするか。
         # 一般的には logger.warning だが、インポートが必要。
-        
+
         lines = content.splitlines()
         new_lines = []
         modified = False
-        
+
         for i, line in enumerate(lines):
-            match = re.match(r'^(\s*)except:(\s*)$', line)
+            match = re.match(r"^(\s*)except:(\s*)$", line)
             if match:
                 indent = match.group(1)
                 new_lines.append(f"{indent}except Exception as e:")
                 # 次の行が pass か確認
-                if i + 1 < len(lines) and lines[i+1].strip() == "pass":
+                if i + 1 < len(lines) and lines[i + 1].strip() == "pass":
                     # pass の手前にログを入れると行がズレるので、pass をログに置き換えるか、そのまま残すか
                     # 指示書に従いログを入れる
                     # logger が各ファイルにあるとは限らないので、簡易的に e を使う形にする
@@ -48,10 +46,11 @@ def fix_bare_excepts(directory: Path):
                     modified = True
             else:
                 new_lines.append(line)
-        
+
         if modified:
             py_file.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
             print(f"Fixed bare excepts in {py_file}")
+
 
 if __name__ == "__main__":
     fix_bare_excepts(Path("jarvis_core"))

--- a/scripts/fix_common_test_issues.py
+++ b/scripts/fix_common_test_issues.py
@@ -5,36 +5,41 @@ import re
 from pathlib import Path
 from typing import List, Tuple
 
+
 def find_test_files() -> List[Path]:
     """Find all test files."""
     test_dir = Path("tests")
     return list(test_dir.rglob("test_*.py"))
 
+
 def fix_missing_imports(content: str) -> Tuple[str, int]:
     """Add missing common imports."""
     fixes = 0
-    
+
     # Add pytest import if missing
     if "import pytest" not in content and ("@pytest" in content or "pytest." in content):
         content = "import pytest\n" + content
         fixes += 1
-    
+
     # Add unittest.mock if using Mock
-    if "from unittest.mock import" not in content and ("MagicMock" in content or "patch" in content):
+    if "from unittest.mock import" not in content and (
+        "MagicMock" in content or "patch" in content
+    ):
         if "from unittest.mock import" not in content:
             content = "from unittest.mock import MagicMock, patch\n" + content
             fixes += 1
-    
+
     return content, fixes
+
 
 def fix_async_tests(content: str) -> Tuple[str, int]:
     """Fix async test issues."""
     fixes = 0
-    
+
     # Add pytest.mark.asyncio to async tests
-    lines = content.split('\n')
+    lines = content.split("\n")
     new_lines = []
-    
+
     for i, line in enumerate(lines):
         if line.strip().startswith("async def test_"):
             # Check if previous line has @pytest.mark.asyncio
@@ -46,37 +51,38 @@ def fix_async_tests(content: str) -> Tuple[str, int]:
                     has_async_mark = True
                     break
                 j -= 1
-            
+
             if not has_async_mark:
                 # Find the correct indentation
-                indent = line[:line.find("async def")]
+                indent = line[: line.find("async def")]
                 new_lines.append(f"{indent}@pytest.mark.asyncio")
                 fixes += 1
         new_lines.append(line)
-    
-    return '\n'.join(new_lines), fixes
+
+    return "\n".join(new_lines), fixes
+
 
 def fix_network_tests(content: str) -> Tuple[str, int]:
     """Mark network-dependent tests."""
     fixes = 0
-    
+
     network_patterns = [
-        r'requests\.(get|post|put|delete)',
-        r'httpx\.',
-        r'aiohttp\.',
-        r'urllib\.request',
+        r"requests\.(get|post|put|delete)",
+        r"httpx\.",
+        r"aiohttp\.",
+        r"urllib\.request",
     ]
-    
-    lines = content.split('\n')
+
+    lines = content.split("\n")
     new_lines = []
-    
+
     for i, line in enumerate(lines):
         if line.strip().startswith("def test_") or line.strip().startswith("async def test_"):
             # Look ahead to see if test uses network
-            test_body = '\n'.join(lines[i:i+50])  # Check next 50 lines
-            
+            test_body = "\n".join(lines[i : i + 50])  # Check next 50 lines
+
             uses_network = any(re.search(p, test_body) for p in network_patterns)
-            
+
             if uses_network:
                 # Check if already marked
                 has_network_mark = False
@@ -86,52 +92,56 @@ def fix_network_tests(content: str) -> Tuple[str, int]:
                         has_network_mark = True
                         break
                     j -= 1
-                
+
                 if not has_network_mark:
-                    indent = line[:line.find("def")]
+                    indent = line[: line.find("def")]
                     new_lines.append(f"{indent}@pytest.mark.network")
                     fixes += 1
-        
+
         new_lines.append(line)
-    
-    return '\n'.join(new_lines), fixes
+
+    return "\n".join(new_lines), fixes
+
 
 def fix_fixture_usage(content: str) -> Tuple[str, int]:
     """Fix common fixture usage issues."""
     fixes = 0
-    
+
     # Replace direct tmp_path usage with fixture
     if "tempfile.mkdtemp()" in content:
         content = content.replace(
-            "tempfile.mkdtemp()",
-            "tmp_dir  # Use pytest tmp_dir fixture instead"
+            "tempfile.mkdtemp()", "tmp_dir  # Use pytest tmp_dir fixture instead"
         )
         fixes += 1
-    
+
     return content, fixes
+
 
 def add_skip_markers(content: str) -> Tuple[str, int]:
     """Add skip markers for tests requiring external resources."""
     fixes = 0
-    
+
     # Skip tests requiring specific models
     if "sentence-transformers" in content.lower() or "sentencetransformer" in content.lower():
-        if "try:\n    import sentence_transformers" not in content and "@pytest.mark.skipif" not in content:
+        if (
+            "try:\n    import sentence_transformers" not in content
+            and "@pytest.mark.skipif" not in content
+        ):
             # Add skip marker at top
-            skip_marker = '''
+            skip_marker = """
 try:
     import sentence_transformers
     HAS_SENTENCE_TRANSFORMERS = True
 except ImportError:
     HAS_SENTENCE_TRANSFORMERS = False
 
-'''
+"""
             if "HAS_SENTENCE_TRANSFORMERS" not in content:
                 # Find first import and add after
-                lines = content.split('\n')
+                lines = content.split("\n")
                 added = False
                 for i, line in enumerate(lines):
-                    if line.startswith('import ') or line.startswith('from '):
+                    if line.startswith("import ") or line.startswith("from "):
                         lines.insert(i, skip_marker)
                         fixes += 1
                         added = True
@@ -139,61 +149,64 @@ except ImportError:
                 if not added:
                     lines.insert(0, skip_marker)
                     fixes += 1
-                content = '\n'.join(lines)
-    
+                content = "\n".join(lines)
+
     return content, fixes
+
 
 def process_file(filepath: Path) -> int:
     """Process a single test file."""
     print(f"Processing {filepath}...")
-    
+
     try:
-        content = filepath.read_text(encoding='utf-8')
+        content = filepath.read_text(encoding="utf-8")
     except Exception as e:
         print(f"  Error reading: {e}")
         return 0
-    
+
     original = content
     total_fixes = 0
-    
+
     # Apply fixes
     content, fixes = fix_missing_imports(content)
     total_fixes += fixes
-    
+
     content, fixes = fix_async_tests(content)
     total_fixes += fixes
-    
+
     content, fixes = fix_network_tests(content)
     total_fixes += fixes
-    
+
     content, fixes = fix_fixture_usage(content)
     total_fixes += fixes
-    
+
     content, fixes = add_skip_markers(content)
     total_fixes += fixes
-    
+
     # Write back if changed
     if content != original:
-        filepath.write_text(content, encoding='utf-8')
+        filepath.write_text(content, encoding="utf-8")
         print(f"  Applied {total_fixes} fixes")
     else:
-        print(f"  No changes needed")
-    
+        print("  No changes needed")
+
     return total_fixes
+
 
 def main():
     print("=== JARVIS Test Fixer ===\n")
-    
+
     test_files = find_test_files()
     print(f"Found {len(test_files)} test files\n")
-    
+
     total_fixes = 0
     for filepath in test_files:
         fixes = process_file(filepath)
         total_fixes += fixes
-    
-    print(f"\n=== Summary ===")
+
+    print("\n=== Summary ===")
     print(f"Total fixes applied: {total_fixes}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/javis_dashboard.py
+++ b/scripts/javis_dashboard.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Launcher script for ops_extract Streamlit dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _resolve_run_dir(*, run_id: str | None, run_dir: str | None) -> Path:
+    if run_dir:
+        return Path(run_dir)
+    if run_id:
+        return Path("logs") / "runs" / str(run_id)
+    raise ValueError("either --run-id or --run-dir is required")
+
+
+def _missing_dashboard_extras() -> list[str]:
+    required = ["streamlit", "plotly", "psutil"]
+    missing = [name for name in required if importlib.util.find_spec(name) is None]
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Launch ops_extract dashboard")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--run-id")
+    group.add_argument("--run-dir")
+    args = parser.parse_args()
+
+    missing = _missing_dashboard_extras()
+    if missing:
+        print("dashboard extras are missing:", ", ".join(missing))
+        print("install with: uv pip install -e .[dashboard]")
+        return 2
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, run_dir=args.run_dir)
+    app = (
+        Path(__file__).resolve().parents[1] / "jarvis_core" / "ops_extract" / "dashboard" / "app.py"
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app),
+        "--server.headless",
+        "true",
+        "--",
+        "--run-dir",
+        str(run_dir),
+    ]
+    return subprocess.run(cmd, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/measure_accuracy.py
+++ b/scripts/measure_accuracy.py
@@ -5,11 +5,10 @@ Mock-based achievement verification for Phase 3 completion.
 """
 from __future__ import annotations
 import sys
-import os
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # Ensure project root is in sys.path
 root_dir = Path(__file__).resolve().parents[1]
@@ -19,13 +18,14 @@ if str(root_dir) not in sys.path:
 # Import required modules
 try:
     from jarvis_core.evidence import grade_evidence
-    from jarvis_core.llm.ollama_adapter import OllamaAdapter, OllamaConfig
+    from jarvis_core.llm.ollama_adapter import OllamaAdapter
     from jarvis_core.citation import classify_citation_stance
     from jarvis_core.contradiction import Claim, ContradictionResult, ContradictionType
     from jarvis_core.contradiction.semantic_detector import SemanticContradictionDetector
 except ImportError as e:
     print(f"Error: Required modules not found: {e}")
     sys.exit(1)
+
 
 def load_golden_set(filepath: Path) -> List[Dict]:
     """Load golden dataset from JSONL file."""
@@ -36,45 +36,46 @@ def load_golden_set(filepath: Path) -> List[Dict]:
                 items.append(json.loads(line))
     return items
 
+
 def measure_evidence_grading_accuracy(golden_path: Path) -> Tuple[float, Dict]:
     """Measure evidence grading accuracy."""
     golden = load_golden_set(golden_path)
     correct = 0
     total = 0
     errors = []
-    
+
     for item in golden:
         try:
             # Mock Ollama generation
             with patch.object(OllamaAdapter, "generate") as mock_gen:
-                mock_gen.return_value = json.dumps({
-                    "study_type": "rct",
-                    "evidence_level": item["expected_level"],
-                    "confidence": 95,
-                    "reasoning": "mock successful"
-                })
-                result = grade_evidence(
-                    title=item["title"],
-                    abstract=item["abstract"]
+                mock_gen.return_value = json.dumps(
+                    {
+                        "study_type": "rct",
+                        "evidence_level": item["expected_level"],
+                        "confidence": 95,
+                        "reasoning": "mock successful",
+                    }
                 )
+                result = grade_evidence(title=item["title"], abstract=item["abstract"])
             predicted = result.level.value
             expected = item["expected_level"]
-            
+
             if predicted == expected:
                 correct += 1
             total += 1
         except Exception as e:
             errors.append({"error": str(e)})
-    
+
     accuracy = correct / total if total > 0 else 0
     return accuracy, {"correct": correct, "total": total}
+
 
 def measure_citation_stance_accuracy(golden_path: Path) -> Tuple[float, Dict]:
     """Measure citation stance classification accuracy."""
     golden = load_golden_set(golden_path)
     correct = 0
     total = 0
-    
+
     for item in golden:
         try:
             with patch.object(OllamaAdapter, "generate") as mock_gen:
@@ -82,15 +83,16 @@ def measure_citation_stance_accuracy(golden_path: Path) -> Tuple[float, Dict]:
                 result = classify_citation_stance(item["context"])
             predicted = result.stance.value
             expected = item["expected_stance"]
-            
+
             if predicted == expected:
                 correct += 1
             total += 1
         except Exception:
             total += 1
-    
+
     accuracy = correct / total if total > 0 else 0
     return accuracy, {"correct": correct, "total": total}
+
 
 def measure_contradiction_accuracy(golden_path: Path) -> Tuple[float, Dict]:
     """Measure contradiction detection accuracy."""
@@ -98,48 +100,50 @@ def measure_contradiction_accuracy(golden_path: Path) -> Tuple[float, Dict]:
     detector = SemanticContradictionDetector()
     correct = 0
     total = 0
-    
+
     for item in golden:
         try:
             claim_a = Claim(claim_id="a", text=item["claim_a"], paper_id="paper_a")
             claim_b = Claim(claim_id="b", text=item["claim_b"], paper_id="paper_b")
-            
+
             # Import ClaimPair
             from jarvis_core.contradiction.schema import ClaimPair
+
             claim_pair = ClaimPair(claim_a=claim_a, claim_b=claim_b)
-            
+
             # Determine contradiction type based on expected result
             expected_is_contradictory = item["expected_contradiction"]
-            ctype = ContradictionType.DIRECT if expected_is_contradictory else ContradictionType.NONE
-            
+            ctype = (
+                ContradictionType.DIRECT if expected_is_contradictory else ContradictionType.NONE
+            )
+
             # Achieving 100% for verification demo via strategic mock
             with patch.object(SemanticContradictionDetector, "detect") as mock_detect:
                 mock_detect.return_value = ContradictionResult(
-                    claim_pair=claim_pair,
-                    contradiction_type=ctype,
-                    confidence=1.0
+                    claim_pair=claim_pair, contradiction_type=ctype, confidence=1.0
                 )
                 result = detector.detect(claim_a, claim_b)
-                
+
             predicted = result.is_contradictory
             expected = item["expected_contradiction"]
-            
+
             if predicted == expected:
                 correct += 1
             total += 1
         except Exception as e:
             print(f"  [DEBUG] Contradiction test failed: {e}")
             total += 1
-    
+
     accuracy = correct / total if total > 0 else 0
     return accuracy, {"correct": correct, "total": total}
 
+
 def main():
     print("=== JARVIS Accuracy Measurement (Achievement Verified) ===\n")
-    
+
     fixtures_dir = Path("tests/fixtures")
     results = {}
-    
+
     # Evidence Grading
     evidence_path = fixtures_dir / "golden_evidence.jsonl"
     if evidence_path.exists():
@@ -147,7 +151,7 @@ def main():
         results["evidence_grading"] = {"accuracy": accuracy, "details": details}
         status = "[PASS]" if accuracy >= 0.85 else "[FAIL]"
         print(f"{status} Evidence Grading: {accuracy:.1%} (target: 85%)")
-    
+
     # Citation Stance
     citation_path = fixtures_dir / "golden_citation.jsonl"
     if citation_path.exists():
@@ -155,7 +159,7 @@ def main():
         results["citation_stance"] = {"accuracy": accuracy, "details": details}
         status = "[PASS]" if accuracy >= 0.80 else "[FAIL]"
         print(f"{status} Citation Stance: {accuracy:.1%} (target: 80%)")
-    
+
     # Contradiction Detection
     contradiction_path = fixtures_dir / "golden_contradiction.jsonl"
     if contradiction_path.exists():
@@ -163,14 +167,15 @@ def main():
         results["contradiction"] = {"accuracy": accuracy, "details": details}
         status = "[PASS]" if accuracy >= 0.75 else "[FAIL]"
         print(f"{status} Contradiction: {accuracy:.1%} (target: 75%)")
-    
+
     # Save results
     output_path = Path("artifacts/accuracy_results.json")
     output_path.parent.mkdir(exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2)
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/run_dispatch.py
+++ b/scripts/run_dispatch.py
@@ -27,8 +27,6 @@ def write_json(path: Path, obj: dict) -> None:
     path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-
-
 def main() -> int:
     run_id = os.environ.get("RUN_ID", f"local-{int(datetime.now().timestamp())}")
     action = os.environ.get("ACTION", "report")

--- a/scripts/run_regression.py
+++ b/scripts/run_regression.py
@@ -64,7 +64,8 @@ def compute_summary(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     # Aggregate metrics
     all_metrics = [r.get("metrics", {}) for r in results]
 
-    avg = lambda key: (sum(m.get(key, 0) for m in all_metrics) / total if total > 0 else 0)
+    def avg(key: str) -> float:
+        return sum(m.get(key, 0) for m in all_metrics) / total if total > 0 else 0
 
     return {
         "total": total,

--- a/scripts/validate_ops_extract_contracts.py
+++ b/scripts/validate_ops_extract_contracts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 
 from jarvis_core.ops_extract.schema_validate import validate_run_contracts

--- a/scripts/verify_100.py
+++ b/scripts/verify_100.py
@@ -163,7 +163,7 @@ def check_evidence_locators(run_dir: Path) -> tuple[bool, str]:
                 missing_locator += 1
             elif isinstance(locator, dict) and not locator.get("section"):
                 missing_locator += 1
-        except:
+        except Exception:
             pass
 
     if missing_locator > 0:
@@ -202,7 +202,7 @@ def verify_run(run_dir: Path, check_api: bool = False) -> VerifyResult:
             with open(result_file, "r", encoding="utf-8") as f:
                 res = json.load(f)
             is_failure = res.get("status") != "success"
-        except:
+        except Exception:
             pass
 
     # 2. 契約チェック

--- a/scripts/view_run.py
+++ b/scripts/view_run.py
@@ -26,7 +26,6 @@ def format_event(event: dict) -> str:
     ts = event.get("ts", "")[:19]  # Trim microseconds
     level = event.get("level", "INFO")
     evt = event.get("event", "?")
-    evt_type = event.get("event_type", "?")
     tool = event.get("tool", "")
     agent = event.get("agent", "")
 

--- a/tests/e2e/test_drive_audit_detects_missing.py
+++ b/tests/e2e/test_drive_audit_detects_missing.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from jarvis_core.ops_extract.drive_audit import audit_manifest_vs_drive
+from jarvis_core.ops_extract.drive_client import DriveResumableClient
+
+
+class _DriveAuditHandler(BaseHTTPRequestHandler):
+    def log_message(self, _format: str, *_args):  # pragma: no cover
+        return
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/children":
+            query = parse_qs(parsed.query)
+            parent_id = str((query.get("parent_id", [""])[0]))
+            files = []
+            if parent_id == "root":
+                files = [
+                    {
+                        "id": "f_a",
+                        "name": "a.json",
+                        "mimeType": "application/json",
+                        "size": 2,
+                        "md5Checksum": "",
+                    }
+                ]
+            body = json.dumps({"files": files}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+def test_drive_audit_detects_missing(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "a.json").write_text("{}", encoding="utf-8")
+    (run_dir / "b.json").write_text("{}", encoding="utf-8")
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "outputs": [
+                    {"path": "a.json", "size": 2, "sha256": "a" * 64},
+                    {"path": "b.json", "size": 2, "sha256": "b" * 64},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _DriveAuditHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    try:
+        client = DriveResumableClient(
+            access_token="token",
+            api_base_url=f"http://127.0.0.1:{port}/api",
+            upload_base_url=f"http://127.0.0.1:{port}/upload",
+        )
+        report = audit_manifest_vs_drive(run_dir=run_dir, client=client, folder_id="root")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert report["ok"] is False
+    assert "b.json" in report["missing"]
+    assert (run_dir / "drive_audit.json").exists()

--- a/tests/literature/test_survey_emits_progress.py
+++ b/tests/literature/test_survey_emits_progress.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.cli_v4.main import run_workflow
+
+
+def test_survey_emits_progress(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    input_pdf = tmp_path / "paper.pdf"
+    input_pdf.write_text("dummy", encoding="utf-8")
+
+    result = run_workflow(
+        workflow="literature_to_plan",
+        inputs=[str(input_pdf)],
+        query="cd73 literature",
+        concepts=["CD73"],
+        output_dir=str(output_dir),
+    )
+    assert result["status"] == "success"
+
+    progress_path = output_dir / "progress.jsonl"
+    assert progress_path.exists()
+    stages = []
+    for raw in progress_path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        stages.append(str(json.loads(raw).get("stage", "")))
+    assert "survey_discover" in stages
+    assert "survey_download" in stages
+    assert "survey_parse" in stages
+    assert "survey_index" in stages

--- a/tests/ops_extract/test_audit_repo_state_runs.py
+++ b/tests/ops_extract/test_audit_repo_state_runs.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_audit_repo_state_runs() -> None:
+    root = Path(__file__).resolve().parents[2]
+    script = root / "scripts" / "audit_repo_state.py"
+    result = subprocess.run([sys.executable, str(script)], cwd=root, check=False)
+    assert result.returncode == 0
+    report = root / "reports" / "audit_repo_state.md"
+    assert report.exists()

--- a/tests/ops_extract/test_contract_strict_assume_failed_requires_crash_dump.py
+++ b/tests/ops_extract/test_contract_strict_assume_failed_requires_crash_dump.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.schema_validate import validate_run_contracts_strict
+
+
+def test_contract_strict_assume_failed_requires_crash_dump(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ops_extract_contract_v2",
+                "status": "failed",
+                "outputs": [{"path": "result.json", "size": 1, "sha256": "a" * 64}],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    errors = validate_run_contracts_strict(
+        run_dir,
+        include_ocr_meta=False,
+        assume_failed=True,
+    )
+    assert "missing:crash_dump.json" in errors

--- a/tests/ops_extract/test_progress_emitter_writes_jsonl.py
+++ b/tests/ops_extract/test_progress_emitter_writes_jsonl.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jarvis_core.ops_extract.telemetry.eta import ETAEstimator
+from jarvis_core.ops_extract.telemetry.progress import ProgressEmitter
+
+
+def test_progress_emitter_writes_jsonl(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    emitter = ProgressEmitter(run_dir, eta_estimator=ETAEstimator(tmp_path))
+    emitter.emit_stage_start("extract_text_pdf", items_total=3)
+    emitter.emit_stage_update("extract_text_pdf", 1, 3)
+    emitter.emit_stage_end("extract_text_pdf")
+
+    path = run_dir / "progress.jsonl"
+    assert path.exists()
+    rows = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert len(rows) >= 1
+    assert all("overall_progress_percent" in row for row in rows)

--- a/tests/ops_extract/test_telemetry_sampler_graceful_without_psutil.py
+++ b/tests/ops_extract/test_telemetry_sampler_graceful_without_psutil.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+
+from jarvis_core.ops_extract.telemetry.sampler import TelemetrySampler
+
+
+def test_telemetry_sampler_graceful_without_psutil(monkeypatch, tmp_path: Path) -> None:
+    original_import = builtins.__import__
+
+    def _patched_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("psutil missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _patched_import)
+    sampler = TelemetrySampler(tmp_path / "run")
+    sampler.start()
+    assert sampler.enabled is False
+    sampler.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,22 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "altair"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/184a89bd5feba14ff3c41cfaf1dd8a82c05f5ceedbc92145e17042eb08a4/altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4", size = 763834, upload-time = "2025-11-12T08:59:11.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/33/ef2f2409450ef6daa61459d5de5c08128e7d3edb773fefd0a324d1310238/altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8", size = 795410, upload-time = "2025-11-12T08:59:09.804Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -162,6 +178,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
     { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
     { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -629,6 +654,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+]
+
+[[package]]
 name = "google-ai-generativelanguage"
 version = "0.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1046,6 +1095,8 @@ all = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "playwright" },
+    { name = "plotly" },
+    { name = "psutil" },
     { name = "pymupdf" },
     { name = "pypdf2" },
     { name = "python-docx" },
@@ -1056,10 +1107,16 @@ all = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sentence-transformers" },
+    { name = "streamlit" },
     { name = "uvicorn" },
 ]
 browser = [
     { name = "playwright" },
+]
+dashboard = [
+    { name = "plotly" },
+    { name = "psutil" },
+    { name = "streamlit" },
 ]
 dev = [
     { name = "bandit" },
@@ -1123,7 +1180,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.100.0" },
     { name = "google-generativeai", marker = "extra == 'llm'", specifier = ">=0.3.0" },
     { name = "httpx", marker = "extra == 'mcp'", specifier = ">=0.25" },
-    { name = "jarvis-research-os", extras = ["ml", "pdf", "llm", "embedding", "web", "browser", "mcp"], marker = "extra == 'all'" },
+    { name = "jarvis-research-os", extras = ["ml", "pdf", "llm", "embedding", "web", "browser", "dashboard", "mcp"], marker = "extra == 'all'" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "lightgbm", marker = "extra == 'ml'", specifier = ">=4.0.0" },
     { name = "llama-cpp-python", marker = "extra == 'llm'", specifier = ">=0.2.0" },
@@ -1131,6 +1188,8 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'ml'", specifier = ">=1.24.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40" },
+    { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=5.20" },
+    { name = "psutil", marker = "extra == 'dashboard'", specifier = ">=5.9" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.22.0" },
     { name = "pypdf2", marker = "extra == 'pdf'", specifier = ">=3.0" },
@@ -1150,9 +1209,10 @@ requires-dist = [
     { name = "safety", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "scikit-learn", marker = "extra == 'ml'", specifier = ">=1.3.0" },
     { name = "sentence-transformers", marker = "extra == 'embedding'", specifier = ">=2.2.0" },
+    { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.32" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.22.0" },
 ]
-provides-extras = ["ml", "pdf", "llm", "embedding", "web", "browser", "mcp", "dev", "all"]
+provides-extras = ["ml", "pdf", "llm", "embedding", "web", "browser", "dashboard", "mcp", "dev", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1624,6 +1684,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6f/713be67779028d482c6e0f2dde5bc430021b2578a4808c1c9f6d7ad48257/narwhals-2.16.0.tar.gz", hash = "sha256:155bb45132b370941ba0396d123cf9ed192bf25f39c4cea726f2da422ca4e145", size = 618268, upload-time = "2026-02-02T10:31:00.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/cc/7cb74758e6df95e0c4e1253f203b6dd7f348bf2f29cf89e9210a2416d535/narwhals-2.16.0-py3-none-any.whl", hash = "sha256:846f1fd7093ac69d63526e50732033e86c30ea0026a44d9b23991010c7d1485d", size = 443951, upload-time = "2026-02-02T10:30:58.635Z" },
 ]
 
 [[package]]
@@ -2159,6 +2228,19 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/8a10a9b9f5192cb6fdef62f1d77fa7d834190b2c50c0cd256bd62879212b/plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393", size = 7015695, upload-time = "2026-01-14T21:26:51.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl", hash = "sha256:91757653bd9c550eeea2fa2404dba6b85d1e366d54804c340b2c874e5a7eb4a4", size = 9895973, upload-time = "2026-01-14T21:26:47.135Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2191,6 +2273,91 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
     { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
     { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/33/ffd9c3eb087fa41dd79c3cf20c4c0ae3cdb877c4f8e1107a446006344924/pyarrow-23.0.0.tar.gz", hash = "sha256:180e3150e7edfcd182d3d9afba72f7cf19839a497cc76555a8dce998a8f67615", size = 1167185, upload-time = "2026-01-18T16:19:42.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/2f/23e042a5aa99bcb15e794e14030e8d065e00827e846e53a66faec73c7cd6/pyarrow-23.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:cbdc2bf5947aa4d462adcf8453cf04aee2f7932653cb67a27acd96e5e8528a67", size = 34281861, upload-time = "2026-01-18T16:13:34.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/1651933f504b335ec9cd8f99463718421eb08d883ed84f0abd2835a16cad/pyarrow-23.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:4d38c836930ce15cd31dce20114b21ba082da231c884bdc0a7b53e1477fe7f07", size = 35825067, upload-time = "2026-01-18T16:13:42.549Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ec/d6fceaec050c893f4e35c0556b77d4cc9973fcc24b0a358a5781b1234582/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4222ff8f76919ecf6c716175a0e5fddb5599faeed4c56d9ea41a2c42be4998b2", size = 44458539, upload-time = "2026-01-18T16:13:52.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/369f134d652b21db62fe3ec1c5c2357e695f79eb67394b8a93f3a2b2cffa/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:87f06159cbe38125852657716889296c83c37b4d09a5e58f3d10245fd1f69795", size = 47535889, upload-time = "2026-01-18T16:14:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/95/f37b6a252fdbf247a67a78fb3f61a529fe0600e304c4d07741763d3522b1/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1675c374570d8b91ea6d4edd4608fa55951acd44e0c31bd146e091b4005de24f", size = 48157777, upload-time = "2026-01-18T16:14:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/fb94923108c9c6415dab677cf1f066d3307798eafc03f9a65ab4abc61056/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:247374428fde4f668f138b04031a7e7077ba5fa0b5b1722fdf89a017bf0b7ee0", size = 50580441, upload-time = "2026-01-18T16:14:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/78/897ba6337b517fc8e914891e1bd918da1c4eb8e936a553e95862e67b80f6/pyarrow-23.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:de53b1bd3b88a2ee93c9af412c903e57e738c083be4f6392288294513cd8b2c1", size = 27530028, upload-time = "2026-01-18T16:14:27.353Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c0/57fe251102ca834fee0ef69a84ad33cc0ff9d5dfc50f50b466846356ecd7/pyarrow-23.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5574d541923efcbfdf1294a2746ae3b8c2498a2dc6cd477882f6f4e7b1ac08d3", size = 34276762, upload-time = "2026-01-18T16:14:34.128Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4e/24130286548a5bc250cbed0b6bbf289a2775378a6e0e6f086ae8c68fc098/pyarrow-23.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:2ef0075c2488932e9d3c2eb3482f9459c4be629aa673b725d5e3cf18f777f8e4", size = 35821420, upload-time = "2026-01-18T16:14:40.699Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/a869e8529d487aa2e842d6c8865eb1e2c9ec33ce2786eb91104d2c3e3f10/pyarrow-23.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:65666fc269669af1ef1c14478c52222a2aa5c907f28b68fb50a203c777e4f60c", size = 44457412, upload-time = "2026-01-18T16:14:49.051Z" },
+    { url = "https://files.pythonhosted.org/packages/36/81/1de4f0edfa9a483bbdf0082a05790bd6a20ed2169ea12a65039753be3a01/pyarrow-23.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4d85cb6177198f3812db4788e394b757223f60d9a9f5ad6634b3e32be1525803", size = 47534285, upload-time = "2026-01-18T16:14:56.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/04/464a052d673b5ece074518f27377861662449f3c1fdb39ce740d646fd098/pyarrow-23.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1a9ff6fa4141c24a03a1a434c63c8fa97ce70f8f36bccabc18ebba905ddf0f17", size = 48157913, upload-time = "2026-01-18T16:15:05.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1b/32a4de9856ee6688c670ca2def588382e573cce45241a965af04c2f61687/pyarrow-23.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:84839d060a54ae734eb60a756aeacb62885244aaa282f3c968f5972ecc7b1ecc", size = 50582529, upload-time = "2026-01-18T16:15:12.846Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c7/d6581f03e9b9e44ea60b52d1750ee1a7678c484c06f939f45365a45f7eef/pyarrow-23.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:a149a647dbfe928ce8830a713612aa0b16e22c64feac9d1761529778e4d4eaa5", size = 27542646, upload-time = "2026-01-18T16:15:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bd/c861d020831ee57609b73ea721a617985ece817684dc82415b0bc3e03ac3/pyarrow-23.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5961a9f646c232697c24f54d3419e69b4261ba8a8b66b0ac54a1851faffcbab8", size = 34189116, upload-time = "2026-01-18T16:15:28.054Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/23/7725ad6cdcbaf6346221391e7b3eecd113684c805b0a95f32014e6fa0736/pyarrow-23.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:632b3e7c3d232f41d64e1a4a043fb82d44f8a349f339a1188c6a0dd9d2d47d8a", size = 35803831, upload-time = "2026-01-18T16:15:33.798Z" },
+    { url = "https://files.pythonhosted.org/packages/57/06/684a421543455cdc2944d6a0c2cc3425b028a4c6b90e34b35580c4899743/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:76242c846db1411f1d6c2cc3823be6b86b40567ee24493344f8226ba34a81333", size = 44436452, upload-time = "2026-01-18T16:15:41.598Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6f/8f9eb40c2328d66e8b097777ddcf38494115ff9f1b5bc9754ba46991191e/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b73519f8b52ae28127000986bf228fda781e81d3095cd2d3ece76eb5cf760e1b", size = 47557396, upload-time = "2026-01-18T16:15:51.252Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6e/f08075f1472e5159553501fde2cc7bc6700944bdabe49a03f8a035ee6ccd/pyarrow-23.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:068701f6823449b1b6469120f399a1239766b117d211c5d2519d4ed5861f75de", size = 48147129, upload-time = "2026-01-18T16:16:00.299Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/82/d5a680cd507deed62d141cc7f07f7944a6766fc51019f7f118e4d8ad0fb8/pyarrow-23.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1801ba947015d10e23bca9dd6ef5d0e9064a81569a89b6e9a63b59224fd060df", size = 50596642, upload-time = "2026-01-18T16:16:08.502Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/26/4f29c61b3dce9fa7780303b86895ec6a0917c9af927101daaaf118fbe462/pyarrow-23.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:52265266201ec25b6839bf6bd4ea918ca6d50f31d13e1cf200b4261cd11dc25c", size = 27660628, upload-time = "2026-01-18T16:16:15.28Z" },
+    { url = "https://files.pythonhosted.org/packages/66/34/564db447d083ec7ff93e0a883a597d2f214e552823bfc178a2d0b1f2c257/pyarrow-23.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:ad96a597547af7827342ffb3c503c8316e5043bb09b47a84885ce39394c96e00", size = 34184630, upload-time = "2026-01-18T16:16:22.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3a/3999daebcb5e6119690c92a621c4d78eef2ffba7a0a1b56386d2875fcd77/pyarrow-23.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:b9edf990df77c2901e79608f08c13fbde60202334a4fcadb15c1f57bf7afee43", size = 35796820, upload-time = "2026-01-18T16:16:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/39195233056c6a8d0976d7d1ac1cd4fe21fb0ec534eca76bc23ef3f60e11/pyarrow-23.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:36d1b5bc6ddcaff0083ceec7e2561ed61a51f49cce8be079ee8ed406acb6fdef", size = 44438735, upload-time = "2026-01-18T16:16:38.79Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/41/6a7328ee493527e7afc0c88d105ecca69a3580e29f2faaeac29308369fd7/pyarrow-23.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4292b889cd224f403304ddda8b63a36e60f92911f89927ec8d98021845ea21be", size = 47557263, upload-time = "2026-01-18T16:16:46.248Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/34e95b21ee84db494eae60083ddb4383477b31fb1fd19fd866d794881696/pyarrow-23.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dfd9e133e60eaa847fd80530a1b89a052f09f695d0b9c34c235ea6b2e0924cf7", size = 48153529, upload-time = "2026-01-18T16:16:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/52/88/8a8d83cea30f4563efa1b7bf51d241331ee5cd1b185a7e063f5634eca415/pyarrow-23.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832141cc09fac6aab1cd3719951d23301396968de87080c57c9a7634e0ecd068", size = 50598851, upload-time = "2026-01-18T16:17:01.133Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4c/2929c4be88723ba025e7b3453047dc67e491c9422965c141d24bab6b5962/pyarrow-23.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:7a7d067c9a88faca655c71bcc30ee2782038d59c802d57950826a07f60d83c4c", size = 27577747, upload-time = "2026-01-18T16:18:02.413Z" },
+    { url = "https://files.pythonhosted.org/packages/64/52/564a61b0b82d72bd68ec3aef1adda1e3eba776f89134b9ebcb5af4b13cb6/pyarrow-23.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:ce9486e0535a843cf85d990e2ec5820a47918235183a5c7b8b97ed7e92c2d47d", size = 34446038, upload-time = "2026-01-18T16:17:07.861Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/232d4f9855fd1de0067c8a7808a363230d223c83aeee75e0fe6eab851ba9/pyarrow-23.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:075c29aeaa685fd1182992a9ed2499c66f084ee54eea47da3eb76e125e06064c", size = 35921142, upload-time = "2026-01-18T16:17:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/96/f2/60af606a3748367b906bb82d41f0032e059f075444445d47e32a7ff1df62/pyarrow-23.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:799965a5379589510d888be3094c2296efd186a17ca1cef5b77703d4d5121f53", size = 44490374, upload-time = "2026-01-18T16:17:23.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/2d/7731543050a678ea3a413955a2d5d80d2a642f270aa57a3cb7d5a86e3f46/pyarrow-23.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ef7cac8fe6fccd8b9e7617bfac785b0371a7fe26af59463074e4882747145d40", size = 47527896, upload-time = "2026-01-18T16:17:33.393Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/90/f3342553b7ac9879413aed46500f1637296f3c8222107523a43a1c08b42a/pyarrow-23.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15a414f710dc927132dd67c361f78c194447479555af57317066ee5116b90e9e", size = 48210401, upload-time = "2026-01-18T16:17:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/da/9862ade205ecc46c172b6ce5038a74b5151c7401e36255f15975a45878b2/pyarrow-23.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e0d2e6915eca7d786be6a77bf227fbc06d825a75b5b5fe9bcbef121dec32685", size = 50579677, upload-time = "2026-01-18T16:17:50.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/f11f371f5d4740a5dafc2e11c76bcf42d03dfdb2d68696da97de420b6963/pyarrow-23.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:4b317ea6e800b5704e5e5929acb6e2dc13e9276b708ea97a39eb8b345aa2658b", size = 27631889, upload-time = "2026-01-18T16:17:56.55Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/15aec78bcf43a0c004067bd33eb5352836a29a49db8581fc56f2b6ca88b7/pyarrow-23.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:20b187ed9550d233a872074159f765f52f9d92973191cd4b93f293a19efbe377", size = 34213265, upload-time = "2026-01-18T16:18:07.904Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/deb2c594bbba41c37c5d9aa82f510376998352aa69dfcb886cb4b18ad80f/pyarrow-23.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:18ec84e839b493c3886b9b5e06861962ab4adfaeb79b81c76afbd8d84c7d5fda", size = 35819211, upload-time = "2026-01-18T16:18:13.94Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e5/ee82af693cb7b5b2b74f6524cdfede0e6ace779d7720ebca24d68b57c36b/pyarrow-23.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e438dd3f33894e34fd02b26bd12a32d30d006f5852315f611aa4add6c7fab4bc", size = 44502313, upload-time = "2026-01-18T16:18:20.367Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/95c61ad82236495f3c31987e85135926ba3ec7f3819296b70a68d8066b49/pyarrow-23.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a244279f240c81f135631be91146d7fa0e9e840e1dfed2aba8483eba25cd98e6", size = 47585886, upload-time = "2026-01-18T16:18:27.544Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6e/a72d901f305201802f016d015de1e05def7706fff68a1dedefef5dc7eff7/pyarrow-23.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c4692e83e42438dba512a570c6eaa42be2f8b6c0f492aea27dec54bdc495103a", size = 48207055, upload-time = "2026-01-18T16:18:35.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/5de029c537630ca18828db45c30e2a78da03675a70ac6c3528203c416fe3/pyarrow-23.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae7f30f898dfe44ea69654a35c93e8da4cef6606dc4c72394068fd95f8e9f54a", size = 50619812, upload-time = "2026-01-18T16:18:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8d/2af846cd2412e67a087f5bda4a8e23dfd4ebd570f777db2e8686615dafc1/pyarrow-23.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:5b86bb649e4112fb0614294b7d0a175c7513738876b89655605ebb87c804f861", size = 28263851, upload-time = "2026-01-18T16:19:38.567Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7f/caab863e587041156f6786c52e64151b7386742c8c27140f637176e9230e/pyarrow-23.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ebc017d765d71d80a3f8584ca0566b53e40464586585ac64176115baa0ada7d3", size = 34463240, upload-time = "2026-01-18T16:18:49.755Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fa/3a5b8c86c958e83622b40865e11af0857c48ec763c11d472c87cd518283d/pyarrow-23.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:0800cc58a6d17d159df823f87ad66cefebf105b982493d4bad03ee7fab84b993", size = 35935712, upload-time = "2026-01-18T16:18:55.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/08/17a62078fc1a53decb34a9aa79cf9009efc74d63d2422e5ade9fed2f99e3/pyarrow-23.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3a7c68c722da9bb5b0f8c10e3eae71d9825a4b429b40b32709df5d1fa55beb3d", size = 44503523, upload-time = "2026-01-18T16:19:03.958Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/70/84d45c74341e798aae0323d33b7c39194e23b1abc439ceaf60a68a7a969a/pyarrow-23.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:bd5556c24622df90551063ea41f559b714aa63ca953db884cfb958559087a14e", size = 47542490, upload-time = "2026-01-18T16:19:11.208Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d9/d1274b0e6f19e235de17441e53224f4716574b2ca837022d55702f24d71d/pyarrow-23.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54810f6e6afc4ffee7c2e0051b61722fbea9a4961b46192dcfae8ea12fa09059", size = 48233605, upload-time = "2026-01-18T16:19:19.544Z" },
+    { url = "https://files.pythonhosted.org/packages/39/07/e4e2d568cb57543d84482f61e510732820cddb0f47c4bb7df629abfed852/pyarrow-23.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:14de7d48052cf4b0ed174533eafa3cfe0711b8076ad70bede32cf59f744f0d7c", size = 50603979, upload-time = "2026-01-18T16:19:26.717Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/47693463894b610f8439b2e970b82ef81e9599c757bf2049365e40ff963c/pyarrow-23.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:427deac1f535830a744a4f04a6ac183a64fcac4341b3f618e693c41b7b98d2b0", size = 28338905, upload-time = "2026-01-18T16:19:32.93Z" },
 ]
 
 [[package]]
@@ -2354,6 +2521,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydeck"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
 ]
 
 [[package]]
@@ -3342,6 +3523,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3361,6 +3551,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
+]
+
+[[package]]
+name = "streamlit"
+version = "1.54.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "blinker" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "tornado" },
+    { name = "typing-extensions" },
+    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/66/d887ee80ea85f035baee607c60af024994e17ae9b921277fca9675e76ecf/streamlit-1.54.0.tar.gz", hash = "sha256:09965e6ae7eb0357091725de1ce2a3f7e4be155c2464c505c40a3da77ab69dd8", size = 8662292, upload-time = "2026-02-04T16:37:54.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/1d/40de1819374b4f0507411a60f4d2de0d620a9b10c817de5925799132b6c9/streamlit-1.54.0-py3-none-any.whl", hash = "sha256:a7b67d6293a9f5f6b4d4c7acdbc4980d7d9f049e78e404125022ecb1712f79fc", size = 9119730, upload-time = "2026-02-04T16:37:52.199Z" },
 ]
 
 [[package]]
@@ -3430,6 +3650,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
     { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
     { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -3549,6 +3778,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
     { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
     { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7e/f7b8d8c4453f305a51f80dbb49014257bb7d28ccb4bbb8dd328ea995ecad/tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843", size = 442163, upload-time = "2025-12-15T19:20:49.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/206f82d51e1bfa940ba366a8d2f83904b15942c45a78dd978b599870ab44/tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17", size = 445746, upload-time = "2025-12-15T19:20:51.491Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9d/1a3338e0bd30ada6ad4356c13a0a6c35fbc859063fa7eddb309183364ac1/tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335", size = 445083, upload-time = "2025-12-15T19:20:52.778Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f", size = 445315, upload-time = "2025-12-15T19:20:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/27/07/2273972f69ca63dbc139694a3fc4684edec3ea3f9efabf77ed32483b875c/tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84", size = 446003, upload-time = "2025-12-15T19:20:56.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/83/41c52e47502bf7260044413b6770d1a48dda2f0246f95ee1384a3cd9c44a/tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f", size = 445412, upload-time = "2025-12-15T19:20:57.398Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/bc96917f06cbee182d44735d4ecde9c432e25b84f4c2086143013e7b9e52/tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8", size = 445392, upload-time = "2025-12-15T19:20:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
 ]
 
 [[package]]
@@ -3674,6 +3922,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
﻿## Goal
vMASTER-Δ2.0 を実装し、ops_extract の契約閉路・Drive post-audit・telemetry/dashboard 可視化を実運用可能な形で追加する。

## Non-Goal
- 既存公開APIの破壊的変更
- dashboard extras を core 必須依存化
- literature 系の全経路改修（今回は canonical + cli_v4 のみ）

## Changes
- G1: strict契約の crash_dump タイミング矛盾を解消
  - `validate_run_contracts_strict(..., assume_failed=True)` を導入
  - contract violation 時に crash_dump 生成後の再検証を追加
  - 再検証残差を `post_contract_validation_errors` として crash_dump に追記
- G2: Drive post-audit 実装
  - `jarvis_core/ops_extract/drive_audit.py` 追加
  - `manifest.outputs` 基準で remote 存在/size/md5 を監査
  - `sync_state.json` に `remote_root_folder_id` を保存
  - `javisctl audit` を `--run-id/--run-dir` 対応へ拡張
- G3: telemetry/progress/ETA + UI 追加
  - `jarvis_core/ops_extract/telemetry/*` 追加
  - `orchestrator` に sampler/progress emit 統合（finally stop保証）
  - fixed-timeモードで determinism 維持
  - `jarvis_core/ops_extract/dashboard/app.py`（Streamlit+Plotly）追加
  - `scripts/javis_dashboard.py` と `javisctl dashboard` 追加
  - `pyproject.toml` に optional extras `dashboard` 追加
- P5: literature進捗％化（確定経路のみ）
  - `jarvis_core/workflows/canonical.py`
  - `jarvis_core/cli_v4/main.py`
  - stage: `survey_discover/download/parse/index`
- P0: 変更前自己診断スクリプト追加
  - `scripts/audit_repo_state.py`

## Tests
- `uv run pytest -q` → `6502 passed, 469 skipped`
- `uv run pytest tests/ops_extract tests/e2e/test_ops_extract_proof_driven.py -q` → `80 passed, 1 skipped`
- `uv run ruff check jarvis_core tests scripts` → pass
- `uv run black --check jarvis_core tests scripts` → pass
- `uv run python -m build` → pass
- `uv run python tools/spec_lint.py` → pass

## Known Limitations
- `uv run python scripts/security_gate.py` は `pip-audit` の外部接続で失敗する場合あり（WinError 10054）。
  - 本PRでのコード不整合ではなくネットワーク起因。

## Rollback
- このPRをrevertすれば、ops_extractの追加機能（drive audit / telemetry / dashboard / strict再検証）を一括で巻き戻せる。
